### PR TITLE
Levi sqlite deploy

### DIFF
--- a/R/common-connections.R
+++ b/R/common-connections.R
@@ -204,10 +204,19 @@ writeData <- function(MSSQLConnectionString = NULL,
     df[colNumsDTS] <- lapply(df[colNumsDTS], as.character)
   }
   
-  DBI::dbWriteTable(con, tableName, df, append = TRUE)
-  
+  DBI::dbWriteTable(conn = con, 
+                    name = tableName, 
+                    value = df,
+                    append = TRUE)
+
   # Close connection
   DBI::dbDisconnect(con)
-  
-  cat(nrow(df), "rows were inserted into the SQL Server", tableName, "table." )
+
+  # TODO: get success and # of inserted rows from dbWriteTable function  
+  if (is.null(MSSQLConnectionString)) {
+    cat(nrow(df), "rows were inserted into the SQLite", tableName, "table." )    
+  } else {
+    cat(nrow(df), "rows were inserted into the SQL Server", tableName, "table.")
+    
+  }
 }

--- a/R/common-find-trends.R
+++ b/R/common-find-trends.R
@@ -1,8 +1,7 @@
 #' @title
 #' Find any columns that have a trend above a particular threshold
 #' @description
-#' Find numeric columns in data frame that have an absolute slope greater than
-#' that specified via threshold argument.
+#' Search within subgroups and find trends that are six months of longer.
 #' @param df A data frame
 #' @param dateCol A string denoting the date column
 #' @param groupbyCol A string denoting the column by which to group
@@ -29,7 +28,6 @@
 #'dfResult <- findTrends(df = df,
 #'                       dateCol = 'dates',
 #'                       groupbyCol = 'gender')
-#'dfResult
 findTrends <- function(df, dateCol, groupbyCol) {
   df$year <- as.POSIXlt(df[[dateCol]])$year + 1900
   df$month <- as.POSIXlt(df[[dateCol]])$mo + 1

--- a/R/lasso-deployment.R
+++ b/R/lasso-deployment.R
@@ -130,7 +130,7 @@
 #' str(df)
 #' 
 #' ## 2. Train and save the model using DEVELOP
-#' #' set.seed(42)
+#' set.seed(42)
 #' inTest <- df$InTestWindowFLG # save this for deploy
 #' df$InTestWindowFLG <- NULL
 #' 
@@ -164,7 +164,12 @@
 #' 
 #' dL <- LassoDeployment$new(p2)
 #' dL$deploy()
+#' dfOut <- dL$getOutDf()
 #' 
+#' writeData(MSSQLConnectionString = connectionString,
+#'           df = dfOut,
+#'           tableName = 'HCRDeployClassificationBASE')
+#'
 #' print(proc.time() - ptm)
 #' }
 #' 
@@ -235,14 +240,149 @@
 #' p2$impute <- TRUE
 #' p2$debug <- FALSE
 #' p2$cores <- 1
-#' p2$sqlConn <- connection.string
-#' p2$destSchemaTable <- "dbo.HCRDeployRegressionBASE"
 #' 
 #' dL <- LassoDeployment$new(p2)
 #' dL$deploy()
+#' dfOut <- dL$getOutDf()
+#' 
+#' writeData(MSSQLConnectionString = connectionString,
+#'           df = dfOut,
+#'           tableName = 'HCRDeployRegressionBASE')
 #' 
 #' print(proc.time() - ptm)
 #' }
+#'
+#' #### Classification example pulling from CSV and writing to SQLite ####
+#' 
+#' ## 1. Loading data and packages.
+#' ptm <- proc.time()
+#' library(healthcareai)
+#' 
+#' # Can delete these system.file lines in your work
+#' csvfile <- system.file("extdata", 
+#'                        "HCRDiabetesClinical.csv", 
+#'                        package = "healthcareai")
+#'                        
+#' sqliteFile <- system.file("extdata",
+#'                           "unit-test.sqlite",
+#'                           package = "healthcareai")
+#'
+#' # Read in CSV; replace csvfile with 'path/file'
+#' df <- read.csv(file = csvfile, 
+#'                header = TRUE, 
+#'                na.strings = c("NULL", "NA", ""))
+#'
+#' head(df)
+#' str(df)
+#' 
+#' ## 2. Train and save the model using DEVELOP
+#' set.seed(42)
+#' df$PatientID <- NULL # We'll instead use PatientEncounterID
+#' inTest <- df$InTestWindowFLG # save this for deploy
+#' df$InTestWindowFLG <- NULL
+#' 
+#' p <- SupervisedModelDevelopmentParams$new()
+#' p$df <- df
+#' p$type <- "classification"
+#' p$impute <- TRUE
+#' p$grainCol <- "PatientEncounterID"
+#' p$predictedCol <- "ThirtyDayReadmitFLG"
+#' p$debug <- FALSE
+#' p$cores <- 1
+#' 
+#' # Run Lasso
+#' lasso <- LassoDevelopment$new(p)
+#' lasso$run()
+#' 
+#' ## 3. Load saved model and use DEPLOY to generate predictions. 
+#' df$InTestWindowFLG <- inTest # put InTestWindowFLG back in.
+#' 
+#' p2 <- SupervisedModelDeploymentParams$new()
+#' p2$type <- "classification"
+#' p2$df <- df
+#' p2$grainCol <- "PatientEncounterID"
+#' p2$testWindowCol <- "InTestWindowFLG"
+#' p2$predictedCol <- "ThirtyDayReadmitFLG"
+#' p2$impute <- TRUE
+#' p2$debug <- FALSE
+#' p2$cores <- 1
+#' p2$sqlConn <- connection.string
+#' p2$destSchemaTable <- "dbo.HCRDeployClassificationBASE"
+#' 
+#' dL <- LassoDeployment$new(p2)
+#' dL$deploy()
+#' dfOut <- dL$getOutDf()
+#' 
+#' writeData(SQLiteFileName = sqliteFile,
+#'           df = dfOut,
+#'           tableName = 'HCRDeployClassificationBASE')
+#'
+#' print(proc.time() - ptm)
+#'
+#' #### Regression example pulling from CSV and writing to SQLite ####
+#' 
+#' ## 1. Loading data and packages.
+#' ptm <- proc.time()
+#' library(healthcareai)
+#' 
+#' # Can delete these system.file lines in your work
+#' csvfile <- system.file("extdata", 
+#'                        "HCRDiabetesClinical.csv", 
+#'                        package = "healthcareai")
+#'
+#' sqliteFile <- system.file("extdata",
+#'                           "unit-test.sqlite",
+#'                           package = "healthcareai")
+#'
+#' # Read in CSV; replace csvfile with 'path/file'
+#' df <- read.csv(file = csvfile, 
+#'                header = TRUE, 
+#'                na.strings = c("NULL", "NA", ""))
+#'
+#' head(df)
+#' str(df)
+#' 
+#' ## 2. Train and save the model using DEVELOP
+#' set.seed(42)
+#' df$PatientID <- NULL # We'll instead use PatientEncounterID
+#' inTest <- df$InTestWindowFLG # save this for deploy
+#' df$InTestWindowFLG <- NULL
+#' 
+#' p <- SupervisedModelDevelopmentParams$new()
+#' p$df <- df
+#' p$type <- "regression"
+#' p$impute <- TRUE
+#' p$grainCol <- "PatientEncounterID"
+#' p$predictedCol <- "A1CNBR"
+#' p$debug <- FALSE
+#' p$cores <- 1
+#' 
+#' # Run Lasso
+#' lasso <- LassoDevelopment$new(p)
+#' lasso$run()
+#' 
+#' ## 3. Load saved model and use DEPLOY to generate predictions. 
+#' df$InTestWindowFLG <- inTest # put InTestWindowFLG back in.
+#' 
+#' p2 <- SupervisedModelDeploymentParams$new()
+#' p2$type <- "regression"
+#' p2$df <- df
+#' p2$grainCol <- "PatientEncounterID"
+#' p2$testWindowCol <- "InTestWindowFLG"
+#' p2$predictedCol <- "A1CNBR"
+#' p2$impute <- TRUE
+#' p2$debug <- FALSE
+#' p2$cores <- 1
+#' 
+#' dL <- LassoDeployment$new(p2)
+#' dL$deploy()
+#' dfOut <- dL$getOutDf()
+#' 
+#' writeData(SQLiteFileName = sqliteFile,
+#'           df = dfOut,
+#'           tableName = 'HCRDeployRegressionBASE')
+#' 
+#' print(proc.time() - ptm)
 
 LassoDeployment <- R6Class(
   "LassoDeployment",
@@ -345,7 +485,7 @@ LassoDeployment <- R6Class(
       # Calculate ordered factors of importance for each row's prediction
       private$orderedFactors <- t(sapply(1:nrow(private$multiplyRes), function(i) colnames(private$multiplyRes[order(private$multiplyRes[i,
                                                                                                                                          ], decreasing = TRUE)])))
-
+      
       if (isTRUE(self$params$debug)) {
         cat("Data frame after getting column importance ordered", '\n')
         print(private$orderedFactors[1:10, ])
@@ -356,19 +496,15 @@ LassoDeployment <- R6Class(
       dtStamp <- as.POSIXlt(Sys.time())
 
       # Combine grain.col, prediction, and time to be put back into SAM table
+      # TODO: use a common function to reduce lasso-specific code here
       private$outDf <- data.frame(
-        0,
-        # BindingID
-        'R',
-        # BindingNM
-        dtStamp,
-        # LastLoadDTS
-        private$grainTest,
-        # GrainID
-        private$predictions,
-        # PredictedProbab
-        private$orderedFactors[, 1:3]
-      )    # Top 3 Factors
+        0,    # BindingID
+        'R',  # BindingNM
+        dtStamp,                      # LastLoadDTS
+        private$grainTest,            # GrainID
+        private$predictions,          # PredictedProbab
+        private$orderedFactors[, 1:3] # Top 3 Factors
+      )    
 
       predictedResultsName <- ""
       if (self$params$type == "classification") {
@@ -386,33 +522,10 @@ LassoDeployment <- R6Class(
         "Factor2TXT",
         "Factor3TXT"
       )
-
-      if (isTRUE(self$params$debug)) {
-        cat('Dataframe with predictions:', '\n')
-        cat(str(private$outDf), '\n')
-      }
-    },
-
-      saveDataIntoDb = function() {
-      if (isTRUE(self$params$writeToDB)) {
-        # Save df to table in SAM database
-        out <- RODBC::sqlSave(
-          channel = self$params$sqlConn,
-          dat = private$outDf,
-          tablename = self$params$destSchemaTable,
-          append = T,
-          rownames = F,
-          colnames = F,
-          safer = T,
-          nastring = NULL,
-          verbose = self$params$debug
-        )
-  
-        # Print success if insert was successful
-        if (out == 1) {
-          cat('SQL Server insert was successful') # removed '\n' for the unit test
-        }
-      }
+      
+      # Remove row names so df can be written to DB
+      # TODO: in writeData function, find how to ignore row names
+      rownames(private$outDf) <- NULL
     }
   ),
 
@@ -433,11 +546,7 @@ LassoDeployment <- R6Class(
 
     #Override: deploy the model
     deploy = function() {
-      if (isTRUE(self$params$writeToDB)) {
-        # Connect to sql via odbc driver
-        private$connectDataSource()
-      }
-      
+
       # Try to load the model
       tryCatch({
         load("rmodel_var_import_lasso.rda")  # Produces fitLogit object
@@ -468,15 +577,6 @@ LassoDeployment <- R6Class(
 
       # create dataframe for output
       private$createDf()
-      
-      if (isTRUE(self$params$writeToDB)) {
-        # Save data into db
-        private$saveDataIntoDb()
-      }
-
-      if (isTRUE(self$params$writeToDB)) {
-        private$closeDataSource()
-      }
     },
     
     # Surface outDf as attribute for export to Oracle, MySQL, etc

--- a/R/lasso-deployment.R
+++ b/R/lasso-deployment.R
@@ -81,7 +81,6 @@
 #' p2$impute <- TRUE
 #' p2$debug <- FALSE
 #' p2$cores <- 1
-#' p2$writeToDB <- FALSE
 #'
 #' dL <- LassoDeployment$new(p2)
 #' dL$deploy()
@@ -159,14 +158,12 @@
 #' p2$impute <- TRUE
 #' p2$debug <- FALSE
 #' p2$cores <- 1
-#' p2$sqlConn <- connection.string
-#' p2$destSchemaTable <- "dbo.HCRDeployClassificationBASE"
 #' 
 #' dL <- LassoDeployment$new(p2)
 #' dL$deploy()
 #' dfOut <- dL$getOutDf()
 #' 
-#' writeData(MSSQLConnectionString = connectionString,
+#' writeData(MSSQLConnectionString = connection.string,
 #'           df = dfOut,
 #'           tableName = 'HCRDeployClassificationBASE')
 #'
@@ -245,7 +242,7 @@
 #' dL$deploy()
 #' dfOut <- dL$getOutDf()
 #' 
-#' writeData(MSSQLConnectionString = connectionString,
+#' writeData(MSSQLConnectionString = connection.string,
 #'           df = dfOut,
 #'           tableName = 'HCRDeployRegressionBASE')
 #' 
@@ -306,8 +303,6 @@
 #' p2$impute <- TRUE
 #' p2$debug <- FALSE
 #' p2$cores <- 1
-#' p2$sqlConn <- connection.string
-#' p2$destSchemaTable <- "dbo.HCRDeployClassificationBASE"
 #' 
 #' dL <- LassoDeployment$new(p2)
 #' dL$deploy()

--- a/R/lasso-deployment.R
+++ b/R/lasso-deployment.R
@@ -403,18 +403,7 @@ LassoDeployment <- R6Class(
     
     predictions = NA,
     
-    # functions
-    connectDataSource = function() {
-      RODBC::odbcCloseAll()
-      # Convert the connection string into a real connection object.
-      self$params$sqlConn <- RODBC::odbcDriverConnect(self$params$sqlConn)
-      
-    },
-
-    closeDataSource = function() {
-      RODBC::odbcCloseAll()
-    },
-
+    # Functions
     # Predict results
     performPrediction = function() {
       # Index of largest lambda within one cvse of the lambda with lowest cve:

--- a/inst/docs/healthcare-statistics/find-variation.md
+++ b/inst/docs/healthcare-statistics/find-variation.md
@@ -1,16 +1,20 @@
-# Search across subgroups and find high-variation via `findVariation`
+# Search across subgroups and find high variation via `findVariation`
 
 ## What is this?
 In healthcare, outcomes improvement often comes from reducing variation. First, however,
-one must find the group that has 1) oddly high variation (within some measure) 
-and 2) a large number of folks in the cohort, such that an improvement effort is
-worthwhile. This tool solves that problem.
+one must find the group that has 
+  
+  1. Oddly high variation (within some measure).
+  2. A large number of folks in the cohort, such that an improvement effort is worthwhile. 
+  
+This tool solves that problem.
 
 ## Why is it helpful?
 
 One can now quickly search across hundreds of subgroups and various 
 measures (like length of stay, readmissions, missed-payment, etc.) to find
-groups that need improvement.
+groups that need improvement. With most healthcare datasets of <100k rows, 
+this search only takes a few seconds.
 
 ## So, how do we do it?
 

--- a/man/LassoDeployment.Rd
+++ b/man/LassoDeployment.Rd
@@ -140,7 +140,7 @@ head(df)
 str(df)
 
 ## 2. Train and save the model using DEVELOP
-#' set.seed(42)
+set.seed(42)
 inTest <- df$InTestWindowFLG # save this for deploy
 df$InTestWindowFLG <- NULL
 
@@ -174,6 +174,11 @@ p2$destSchemaTable <- "dbo.HCRDeployClassificationBASE"
 
 dL <- LassoDeployment$new(p2)
 dL$deploy()
+dfOut <- dL$getOutDf()
+
+writeData(MSSQLConnectionString = connectionString,
+          df = dfOut,
+          tableName = 'HCRDeployClassificationBASE')
 
 print(proc.time() - ptm)
 }
@@ -245,14 +250,149 @@ p2$predictedCol <- "A1CNBR"
 p2$impute <- TRUE
 p2$debug <- FALSE
 p2$cores <- 1
-p2$sqlConn <- connection.string
-p2$destSchemaTable <- "dbo.HCRDeployRegressionBASE"
 
 dL <- LassoDeployment$new(p2)
 dL$deploy()
+dfOut <- dL$getOutDf()
+
+writeData(MSSQLConnectionString = connectionString,
+          df = dfOut,
+          tableName = 'HCRDeployRegressionBASE')
 
 print(proc.time() - ptm)
 }
+
+#### Classification example pulling from CSV and writing to SQLite ####
+
+## 1. Loading data and packages.
+ptm <- proc.time()
+library(healthcareai)
+
+# Can delete these system.file lines in your work
+csvfile <- system.file("extdata", 
+                       "HCRDiabetesClinical.csv", 
+                       package = "healthcareai")
+                       
+sqliteFile <- system.file("extdata",
+                          "unit-test.sqlite",
+                          package = "healthcareai")
+
+# Read in CSV; replace csvfile with 'path/file'
+df <- read.csv(file = csvfile, 
+               header = TRUE, 
+               na.strings = c("NULL", "NA", ""))
+
+head(df)
+str(df)
+
+## 2. Train and save the model using DEVELOP
+set.seed(42)
+df$PatientID <- NULL # We'll instead use PatientEncounterID
+inTest <- df$InTestWindowFLG # save this for deploy
+df$InTestWindowFLG <- NULL
+
+p <- SupervisedModelDevelopmentParams$new()
+p$df <- df
+p$type <- "classification"
+p$impute <- TRUE
+p$grainCol <- "PatientEncounterID"
+p$predictedCol <- "ThirtyDayReadmitFLG"
+p$debug <- FALSE
+p$cores <- 1
+
+# Run Lasso
+lasso <- LassoDevelopment$new(p)
+lasso$run()
+
+## 3. Load saved model and use DEPLOY to generate predictions. 
+df$InTestWindowFLG <- inTest # put InTestWindowFLG back in.
+
+p2 <- SupervisedModelDeploymentParams$new()
+p2$type <- "classification"
+p2$df <- df
+p2$grainCol <- "PatientEncounterID"
+p2$testWindowCol <- "InTestWindowFLG"
+p2$predictedCol <- "ThirtyDayReadmitFLG"
+p2$impute <- TRUE
+p2$debug <- FALSE
+p2$cores <- 1
+p2$sqlConn <- connection.string
+p2$destSchemaTable <- "dbo.HCRDeployClassificationBASE"
+
+dL <- LassoDeployment$new(p2)
+dL$deploy()
+dfOut <- dL$getOutDf()
+
+writeData(SQLiteFileName = sqliteFile,
+          df = dfOut,
+          tableName = 'HCRDeployClassificationBASE')
+
+print(proc.time() - ptm)
+
+#### Regression example pulling from CSV and writing to SQLite ####
+
+## 1. Loading data and packages.
+ptm <- proc.time()
+library(healthcareai)
+
+# Can delete these system.file lines in your work
+csvfile <- system.file("extdata", 
+                       "HCRDiabetesClinical.csv", 
+                       package = "healthcareai")
+
+sqliteFile <- system.file("extdata",
+                          "unit-test.sqlite",
+                          package = "healthcareai")
+
+# Read in CSV; replace csvfile with 'path/file'
+df <- read.csv(file = csvfile, 
+               header = TRUE, 
+               na.strings = c("NULL", "NA", ""))
+
+head(df)
+str(df)
+
+## 2. Train and save the model using DEVELOP
+set.seed(42)
+df$PatientID <- NULL # We'll instead use PatientEncounterID
+inTest <- df$InTestWindowFLG # save this for deploy
+df$InTestWindowFLG <- NULL
+
+p <- SupervisedModelDevelopmentParams$new()
+p$df <- df
+p$type <- "regression"
+p$impute <- TRUE
+p$grainCol <- "PatientEncounterID"
+p$predictedCol <- "A1CNBR"
+p$debug <- FALSE
+p$cores <- 1
+
+# Run Lasso
+lasso <- LassoDevelopment$new(p)
+lasso$run()
+
+## 3. Load saved model and use DEPLOY to generate predictions. 
+df$InTestWindowFLG <- inTest # put InTestWindowFLG back in.
+
+p2 <- SupervisedModelDeploymentParams$new()
+p2$type <- "regression"
+p2$df <- df
+p2$grainCol <- "PatientEncounterID"
+p2$testWindowCol <- "InTestWindowFLG"
+p2$predictedCol <- "A1CNBR"
+p2$impute <- TRUE
+p2$debug <- FALSE
+p2$cores <- 1
+
+dL <- LassoDeployment$new(p2)
+dL$deploy()
+dfOut <- dL$getOutDf()
+
+writeData(SQLiteFileName = sqliteFile,
+          df = dfOut,
+          tableName = 'HCRDeployRegressionBASE')
+
+print(proc.time() - ptm)
 }
 \seealso{
 \code{\link{healthcareai}}

--- a/man/findTrends.Rd
+++ b/man/findTrends.Rd
@@ -19,8 +19,7 @@ subset the data was grouped by (ie M/F), the measures that had trends
 (ie, mortality or readmission), and the ending month.
 }
 \description{
-Find numeric columns in data frame that have an absolute slope greater than
-that specified via threshold argument.
+Search within subgroups and find trends that are six months of longer.
 }
 \examples{
 dates <- c(as.Date('2012-01-01'),as.Date('2012-01-02'),as.Date('2012-02-01'),
@@ -36,7 +35,6 @@ df <- data.frame(dates,y1,y2,y3,y4,gender)
 dfResult <- findTrends(df = df,
                       dateCol = 'dates',
                       groupbyCol = 'gender')
-dfResult
 }
 \references{
 \url{http://healthcare.ai}

--- a/tests/testthat/test-deploy-pushes-to-sql-server.R
+++ b/tests/testthat/test-deploy-pushes-to-sql-server.R
@@ -1,4 +1,4 @@
-context("Checking deploy predictions from sql to sql")
+context("Checking deploy predictions from sql server to sql server")
 
   connection.string <- "
   driver={SQL Server};
@@ -105,7 +105,7 @@ test_that("LMM deploy regression pushes values to SQL", {
   closeAllConnections()
 }) 
 
-test_that("Lasso deploy classification pushes values to SQL", {
+test_that("Lasso deploy classification pushes values to SQL Server", {
 
   skip_on_travis()
   skip_on_cran()
@@ -133,12 +133,15 @@ test_that("Lasso deploy classification pushes values to SQL", {
   p2$destSchemaTable <- "dbo.HCRDeployClassificationBASE"
   
   capture.output(dL <- LassoDeployment$new(p2))
-  out <- capture.output(dL$deploy())
-  expect_equal(out, "SQL Server insert was successful")
-  closeAllConnections()
+  capture.output(dL$deploy())
+  capture.output(dfOut <- dL$getOutDf())
+  expect_output(writeData(MSSQLConnectionString = connectionString,
+                          df = dfOut,
+                          tableName = 'HCRDeployClassificationBASE'),
+                "13 rows were inserted into the SQL Server")
 })
 
-test_that("Lasso deploy regression pushes values to SQL", {
+test_that("Lasso deploy regression pushes values to SQL Server", {
 
   skip_on_travis()
   skip_on_cran()
@@ -167,11 +170,14 @@ test_that("Lasso deploy regression pushes values to SQL", {
   
   capture.output(dL <- LassoDeployment$new(p2))
   out <- capture.output(dL$deploy())
-  expect_equal(out, "SQL Server insert was successful")
-  closeAllConnections()
+  capture.output(dfOut <- dL$getOutDf())
+  expect_output(writeData(MSSQLConnectionString = connectionString,
+                          df = dfOut,
+                          tableName = 'HCRDeployRegressionBASE'),
+                "13 rows were inserted into the SQL Server")
 })
 
-test_that("rf deploy classification pushes values to SQL", {
+test_that("rf deploy classification pushes values to SQL Server", {
 
   skip_on_travis()
   skip_on_cran()
@@ -204,7 +210,7 @@ test_that("rf deploy classification pushes values to SQL", {
   closeAllConnections()
 })
 
-test_that("rf deploy regression pushes values to SQL", {
+test_that("rf deploy regression pushes values to SQL Server", {
 
   skip_on_travis()
   skip_on_cran()

--- a/tests/testthat/test-deploy-pushes-to-sqlite.R
+++ b/tests/testthat/test-deploy-pushes-to-sqlite.R
@@ -1,0 +1,95 @@
+context("Checking deploy predictions from csv to sqlite")
+
+csvfile <- system.file("extdata",
+                       "HCRDiabetesClinical.csv",
+                       package = "healthcareai")
+
+sqliteFile <- system.file("extdata",
+                          "unit-test.sqlite",
+                          package = "healthcareai")
+
+df <- read.csv(file = csvfile,
+               header = TRUE,
+               na.strings = c("NULL", "NA", ""))
+
+inTest <- df$InTestWindowFLG # save this for deploy
+
+set.seed(43)
+p <- SupervisedModelDevelopmentParams$new()
+p$df = df
+p$grainCol = 'PatientEncounterID'
+p$impute = TRUE
+p$debug = FALSE
+p$cores = 1
+p$tune = FALSE
+p$numberOfTrees = 201
+
+#### BEGIN TESTS ####
+
+test_that("Lasso deploy classification pushes values to SQLite", {
+  
+  df$PatientID <- NULL #<- Note this happens affects all following tests
+  df$InTestWindowFLG <- NULL
+  
+  p <- initializeParamsForTesting(df)
+  p$type = 'classification'
+  p$predictedCol = 'ThirtyDayReadmitFLG'
+  # Run Lasso
+  lasso <- LassoDevelopment$new(p)
+  capture.output(lasso$run())
+  
+  df$InTestWindowFLG <- inTest # put InTestWindowFLG back in
+  
+  p2 <- SupervisedModelDeploymentParams$new()
+  p2$type = 'classification'
+  p2$df = df
+  p2$grainCol = 'PatientEncounterID'
+  p2$testWindowCol = 'InTestWindowFLG'
+  p2$predictedCol = 'ThirtyDayReadmitFLG'
+  p2$impute = TRUE
+  p2$sqlConn <- connection.string
+  p2$destSchemaTable <- "dbo.HCRDeployClassificationBASE"
+  
+  capture.output(dL <- LassoDeployment$new(p2))
+  capture.output(dL$deploy())
+  capture.output(dfOut <- dL$getOutDf())
+  expect_output(writeData(SQLiteFileName = sqliteFile,
+                          df = dfOut,
+                          tableName = 'HCRDeployClassificationBASE'),
+                "13 rows were inserted into the SQLite")
+})
+
+test_that("Lasso deploy regression pushes values to SQLite", {
+
+  df$InTestWindowFLG <- NULL
+  
+  p <- initializeParamsForTesting(df)
+  p$type = 'regression'
+  p$predictedCol = 'A1CNBR'
+  
+  # Run Lasso
+  lasso <- LassoDevelopment$new(p)
+  capture.output(lasso$run())
+  
+  df$InTestWindowFLG <- inTest # put InTestWindowFLG back in
+  
+  p2 <- SupervisedModelDeploymentParams$new()
+  p2$type = 'regression'
+  p2$df = df
+  p2$grainCol = 'PatientEncounterID'
+  p2$testWindowCol = 'InTestWindowFLG'
+  p2$predictedCol = 'A1CNBR'
+  p2$impute = TRUE
+  p2$sqlConn <- connection.string
+  p2$destSchemaTable <- "dbo.HCRDeployRegressionBASE"
+  
+  capture.output(dL <- LassoDeployment$new(p2))
+  capture.output(dL$deploy())
+  capture.output(dfOut <- dL$getOutDf())
+  expect_output(writeData(SQLiteFileName = sqliteFile,
+                          df = dfOut,
+                          tableName = 'HCRDeployRegressionBASE'),
+                "13 rows were inserted into the SQLite")
+  
+  closeAllConnections()
+})


### PR DESCRIPTION
Have finished this for Lasso:

removing SQL insert in deploy class (and removing row labels)
fixing two roxygen SQL Server examples
adding two roxygen SQLite examples (that aren't turned off for CRAN)
adding unit tests to the new test-deploy-pushes-to-sqlite.R
fixing unit tests in test-deploy-pushes-to-sql-server.R
Finally, removed RODBC from:
- DESCRIPTION
- any download instructions for Travis-MAC
- any install instructions in README and mkdocs index page
This should fix Travis build!

Would be good to do a final sweep and make sure the following params are now deleted or give helpful warning messages (saying they were deprecated). May have to remove the default from supervised-model-deployment, so these warnings aren't always triggered.

- sqlConn
- destSchemaTable
- writeToDB

Not sure what your plan was to remove `InTestWindowFLG`, but it'd require a lot of changes to SQL queries in roxygen and unit tests, so may be best done in a separate PR. So awesome though to be getting rid of these params!

Closes #360
Closes #361 (when Mike does rf/LMM)