### PR TITLE
Updated SQL examples in Rf and Lasso code to clean data

### DIFF
--- a/R/lasso-deployment.R
+++ b/R/lasso-deployment.R
@@ -128,6 +128,9 @@
 #' head(df)
 #' str(df)
 #' 
+#' #Make sure all blanks in ThirtyDayReadmitFLG are converted to NAs
+#' df$ThirtyDayReadmitFLG[df$ThirtyDayReadmitFLG == ""] <- NA
+#' 
 #' ## 2. Train and save the model using DEVELOP
 #' set.seed(42)
 #' inTest <- df$InTestWindowFLG # save this for deploy
@@ -206,6 +209,9 @@
 #' 
 #' head(df)
 #' str(df)
+#' 
+#' #Regression problems need predictedCol to be numeric
+#' df$InTestWindowFLG <- as.numeric(df$InTestWindowFLG)
 #' 
 #' ## 2. Train and save the model using DEVELOP
 #' #' set.seed(42)

--- a/R/lasso-deployment.R
+++ b/R/lasso-deployment.R
@@ -211,7 +211,7 @@
 #' str(df)
 #' 
 #' #Regression problems need predictedCol to be numeric
-#' df$InTestWindowFLG <- as.numeric(df$InTestWindowFLG)
+#' df$A1CNBR <- as.numeric(df$A1CNBR)
 #' 
 #' ## 2. Train and save the model using DEVELOP
 #' #' set.seed(42)

--- a/R/lasso-development.R
+++ b/R/lasso-development.R
@@ -126,6 +126,9 @@
 #' df <- selectData(connection.string, query)
 #' head(df)
 #'
+#' #Make sure all blanks in ThirtyDayReadmitFLG are converted to NAs
+#' df$ThirtyDayReadmitFLG[df$ThirtyDayReadmitFLG == ""] <- NA
+#'
 #' set.seed(42)
 #'
 #' p <- SupervisedModelDevelopmentParams$new()

--- a/R/random-forest-deployment.R
+++ b/R/random-forest-deployment.R
@@ -132,6 +132,9 @@
 #' head(df)
 #' str(df)
 #' 
+#' #' #Make sure all blanks in ThirtyDayReadmitFLG are converted to NAs
+#' df$ThirtyDayReadmitFLG[df$ThirtyDayReadmitFLG == ""] <- NA
+#' 
 #' ## 2. Train and save the model using DEVELOP
 #' #' set.seed(42)
 #' inTest <- df$InTestWindowFLG # save this for deploy
@@ -209,6 +212,9 @@
 #' 
 #' head(df)
 #' str(df)
+#' 
+#' #Regression problems need predictedCol to be numeric
+#' df$InTestWindowFLG <- as.numeric(df$InTestWindowFLG)
 #' 
 #' ## 2. Train and save the model using DEVELOP
 #' #' set.seed(42)

--- a/R/random-forest-deployment.R
+++ b/R/random-forest-deployment.R
@@ -214,7 +214,7 @@
 #' str(df)
 #' 
 #' #Regression problems need predictedCol to be numeric
-#' df$InTestWindowFLG <- as.numeric(df$InTestWindowFLG)
+#' df$A1CNBR <- as.numeric(df$A1CNBR)
 #' 
 #' ## 2. Train and save the model using DEVELOP
 #' #' set.seed(42)

--- a/R/random-forest-development.R
+++ b/R/random-forest-development.R
@@ -133,6 +133,9 @@
 #' df <- selectData(connection.string, query)
 #' head(df)
 #'
+#' #Make sure all blanks in ThirtyDayReadmitFLG are converted to NAs
+#' df$ThirtyDayReadmitFLG[df$ThirtyDayReadmitFLG == ""] <- NA
+#'
 #' df$InTestWindowFLG <- NULL
 #'
 #' set.seed(42)

--- a/man/LassoDeployment.Rd
+++ b/man/LassoDeployment.Rd
@@ -221,7 +221,7 @@ head(df)
 str(df)
 
 #Regression problems need predictedCol to be numeric
-df$InTestWindowFLG <- as.numeric(df$InTestWindowFLG)
+df$A1CNBR <- as.numeric(df$A1CNBR)
 
 ## 2. Train and save the model using DEVELOP
 #' set.seed(42)

--- a/man/LassoDeployment.Rd
+++ b/man/LassoDeployment.Rd
@@ -138,6 +138,9 @@ df <- selectData(connection.string, query)
 head(df)
 str(df)
 
+#Make sure all blanks in ThirtyDayReadmitFLG are converted to NAs
+df$ThirtyDayReadmitFLG[df$ThirtyDayReadmitFLG == ""] <- NA
+
 ## 2. Train and save the model using DEVELOP
 set.seed(42)
 inTest <- df$InTestWindowFLG # save this for deploy
@@ -216,6 +219,9 @@ df <- selectData(connection.string, query)
 
 head(df)
 str(df)
+
+#Regression problems need predictedCol to be numeric
+df$InTestWindowFLG <- as.numeric(df$InTestWindowFLG)
 
 ## 2. Train and save the model using DEVELOP
 #' set.seed(42)

--- a/man/LassoDevelopment.Rd
+++ b/man/LassoDevelopment.Rd
@@ -129,6 +129,9 @@ WHERE InTestWindowFLG = 'N'
 df <- selectData(connection.string, query)
 head(df)
 
+#Make sure all blanks in ThirtyDayReadmitFLG are converted to NAs
+df$ThirtyDayReadmitFLG[df$ThirtyDayReadmitFLG == ""] <- NA
+
 set.seed(42)
 
 p <- SupervisedModelDevelopmentParams$new()

--- a/man/RandomForestDeployment.Rd
+++ b/man/RandomForestDeployment.Rd
@@ -223,7 +223,7 @@ head(df)
 str(df)
 
 #Regression problems need predictedCol to be numeric
-df$InTestWindowFLG <- as.numeric(df$InTestWindowFLG)
+df$A1CNBR <- as.numeric(df$A1CNBR)
 
 ## 2. Train and save the model using DEVELOP
 #' set.seed(42)

--- a/man/RandomForestDeployment.Rd
+++ b/man/RandomForestDeployment.Rd
@@ -141,6 +141,9 @@ df <- selectData(connection.string, query)
 head(df)
 str(df)
 
+#' #Make sure all blanks in ThirtyDayReadmitFLG are converted to NAs
+df$ThirtyDayReadmitFLG[df$ThirtyDayReadmitFLG == ""] <- NA
+
 ## 2. Train and save the model using DEVELOP
 #' set.seed(42)
 inTest <- df$InTestWindowFLG # save this for deploy
@@ -218,6 +221,9 @@ df <- selectData(connection.string, query)
 
 head(df)
 str(df)
+
+#Regression problems need predictedCol to be numeric
+df$InTestWindowFLG <- as.numeric(df$InTestWindowFLG)
 
 ## 2. Train and save the model using DEVELOP
 #' set.seed(42)

--- a/man/RandomForestDevelopment.Rd
+++ b/man/RandomForestDevelopment.Rd
@@ -136,6 +136,9 @@ WHERE InTestWindowFLG = 'N'
 df <- selectData(connection.string, query)
 head(df)
 
+#Make sure all blanks in ThirtyDayReadmitFLG are converted to NAs
+df$ThirtyDayReadmitFLG[df$ThirtyDayReadmitFLG == ""] <- NA
+
 df$InTestWindowFLG <- NULL
 
 set.seed(42)


### PR DESCRIPTION
SQL examples in rf and lasso dev and deploy did not have predictedCol
being binary or numeric for classification and regression, respectively.
The csv examples had ways to deal with missing data on import.  The csv
import also recognized the regression's independent variable as numeric
whereas the SQL import did not.