### PR TITLE
Yannick481 - Unit Tests for Factor Level Coercion

### DIFF
--- a/R/lasso-deployment.R
+++ b/R/lasso-deployment.R
@@ -601,8 +601,6 @@ LassoDeployment <- R6Class(
       })
       
       # Make sure factor columns have the training data factor levels
-      # Lasso predict has problems if there are missing or extra factor levels
-      # so this needs to happen before performPrediction
       super$formatFactorColumns()
       # Update self$params$df to reflect the training data factor levels
       self$params$df <- private$dfTestRaw

--- a/R/linear-mixed-model-deployment.R
+++ b/R/linear-mixed-model-deployment.R
@@ -571,9 +571,8 @@ LinearMixedModelDeployment <- R6Class("LinearMixedModelDeployment",
       
       # Make sure factor columns have the training data factor levels
       super$formatFactorColumns()
-      # Update self$params$df to reflect the training data factor levels, 
-      # adding back the person col
-      self$params$df[ ,-which(names(self$params$df) %in% self$params$personCol)] <- private$dfTestRaw
+      # Update self$params$df to reflect the training data factor levels
+      self$params$df <- private$dfTestRaw
       
       # Predict
       private$performPrediction()

--- a/R/linear-mixed-model-deployment.R
+++ b/R/linear-mixed-model-deployment.R
@@ -568,15 +568,19 @@ LinearMixedModelDeployment <- R6Class("LinearMixedModelDeployment",
               and save the model, then Linear Mixed Model deployment to make predictions
               See ?LinearMixedModelDevelopment.')
       })
-
-      # Predict
-      private$performPrediction()
-
-      # Get dummy data based on factors from develop
+      
+      # Make sure factor columns have the training data factor levels
       if (nchar(self$params$personCol) != 0) {
         private$dfTestRaw[[self$params$personCol]] <- NULL
       }
       super$formatFactorColumns()
+      # Update self$params$df to reflect the training data factor levels
+      self$params$df <- private$dfTestRaw
+      
+      # Predict
+      private$performPrediction()
+
+      # Get dummy data based on factors from develop
       super$makeFactorDummies()
 
       # Calculate Coeffcients

--- a/R/linear-mixed-model-deployment.R
+++ b/R/linear-mixed-model-deployment.R
@@ -570,12 +570,10 @@ LinearMixedModelDeployment <- R6Class("LinearMixedModelDeployment",
       })
       
       # Make sure factor columns have the training data factor levels
-      if (nchar(self$params$personCol) != 0) {
-        private$dfTestRaw[[self$params$personCol]] <- NULL
-      }
       super$formatFactorColumns()
-      # Update self$params$df to reflect the training data factor levels
-      self$params$df <- private$dfTestRaw
+      # Update self$params$df to reflect the training data factor levels, 
+      # adding back the person col
+      self$params$df[ ,-which(names(self$params$df) %in% self$params$personCol)] <- private$dfTestRaw
       
       # Predict
       private$performPrediction()

--- a/R/random-forest-deployment.R
+++ b/R/random-forest-deployment.R
@@ -547,12 +547,16 @@ RandomForestDeployment <- R6Class("RandomForestDeployment",
               and save the model, then random forest deployment to make predictions.
               See ?RandomForestDevelopment')
       })
+      
+      # Make sure factor columns have the training data factor levels
+      super$formatFactorColumns()
+      # Update self$params$df to reflect the training data factor levels
+      self$params$df <- private$dfTestRaw
 
       # Predict
       private$performPrediction()
 
       # Get dummy data based on factors from develop
-      super$formatFactorColumns()
       super$makeFactorDummies()
 
       # Calculate Coeffcients

--- a/R/supervised-model-deployment.R
+++ b/R/supervised-model-deployment.R
@@ -213,8 +213,8 @@ SupervisedModelDeployment <- R6Class("SupervisedModelDeployment",
     # Display warning if new categorical variable levels are found
     if (length(newLevels) > 0) {
       warning('New categorical variable levels were found:\n',
-              paste('- ', names(newLevels), ":", newLevels, collapse = "\n"),
-              '\n These values have been set to NA.')
+              paste(' - ', names(newLevels), ":", newLevels, collapse = "\n"),
+              '\nThese values have been set to NA.', sep = "")
     }
     
     # Impute missing values introduced through new factor levels

--- a/R/supervised-model-deployment.R
+++ b/R/supervised-model-deployment.R
@@ -194,6 +194,11 @@ SupervisedModelDeployment <- R6Class("SupervisedModelDeployment",
   formatFactorColumns = function(){
     # Manually Assign factor levels based on which ones were present in training.
     private$dfTestRaw <- self$params$df
+    
+    if (nchar(self$params$personCol) != 0) {
+      private$dfTestRaw[[self$params$personCol]] <- NULL
+    }
+    
     factorLevels <- private$fitLogit$factorLevels
     
     # Check to see if there are new levels in test data vs. training data.

--- a/R/supervised-model-deployment.R
+++ b/R/supervised-model-deployment.R
@@ -163,6 +163,7 @@ SupervisedModelDeployment <- R6Class("SupervisedModelDeployment",
     }
 
     # Impute columns
+    # TODO: impute using training data (currently uses deploy data)
     self$params$df[] <- lapply(self$params$df, imputeColumn)
 
     if (isTRUE(self$params$debug)) {
@@ -218,6 +219,7 @@ SupervisedModelDeployment <- R6Class("SupervisedModelDeployment",
     }
     
     # Impute missing values introduced through new factor levels
+    # TODO: impute using training data (currently uses deploy data)
     private$dfTestRaw[, names(newLevels)] <- sapply(private$dfTestRaw[, names(newLevels)], imputeColumn)
     
     # Assign new factor levels using training data factor levels

--- a/R/supervised-model-deployment.R
+++ b/R/supervised-model-deployment.R
@@ -195,10 +195,6 @@ SupervisedModelDeployment <- R6Class("SupervisedModelDeployment",
     # Manually Assign factor levels based on which ones were present in training.
     private$dfTestRaw <- self$params$df
     
-    if (nchar(self$params$personCol) != 0) {
-      private$dfTestRaw[[self$params$personCol]] <- NULL
-    }
-    
     factorLevels <- private$fitLogit$factorLevels
     
     # Check to see if there are new levels in test data vs. training data.

--- a/R/supervised-model-deployment.R
+++ b/R/supervised-model-deployment.R
@@ -194,7 +194,6 @@ SupervisedModelDeployment <- R6Class("SupervisedModelDeployment",
   formatFactorColumns = function(){
     # Manually Assign factor levels based on which ones were present in training.
     private$dfTestRaw <- self$params$df
-    
     factorLevels <- private$fitLogit$factorLevels
     
     # Check to see if there are new levels in test data vs. training data.

--- a/R/supervised-model-development.R
+++ b/R/supervised-model-development.R
@@ -278,10 +278,6 @@ SupervisedModelDevelopment <- R6Class("SupervisedModelDevelopment",
       # TODO replace this part with LIME.
       private$dfTrainRaw <- private$dfTrain
       private$dfTrainRaw[[self$params$predictedCol]] <- NULL
-      # remove personcol if it exists for variable importance.
-      if (nchar(self$params$personCol) != 0) {
-        private$dfTrainRaw[[self$params$personCol]] <- NULL
-      }
 
       # Get factor levels as a private attribute
       private$factorLevels <- list()

--- a/tests/testthat/test-factor-level-coercion.R
+++ b/tests/testthat/test-factor-level-coercion.R
@@ -155,9 +155,9 @@ test_that("Single row predictions work for RF classification", {
   # Get prediction
   rfOutDf1 <- rfD1$getOutDf()
   
-  # Check that dimensions of prediction dataframe are correct
-  expect_equal(dim(rfOutDf1)[1], 1)
-  expect_equal(dim(rfOutDf1)[2], 8)
+  # Check that a prediction is made
+  expect_equal(rfOutDf1$id[1], 9001)
+  expect_is(rfOutDf1$PredictedProbNBR[1], numeric)
 })
 
 test_that("Single row predictions work for lasso classification", {
@@ -184,9 +184,9 @@ test_that("Single row predictions work for lasso classification", {
   # Get prediction
   lassoOutDf1 <- lassoD1$getOutDf()
   
-  # Check that dimensions of prediction dataframe are correct
-  expect_equal(dim(lassoOutDf1)[1], 1)
-  expect_equal(dim(lassoOutDf1)[2], 8)
+  # Check that a prediction is made
+  expect_equal(lassoOutDf1$id[1], 9001)
+  expect_is(lassoOutDf1$PredictedProbNBR[1], numeric)
 })
 
 test_that("RF classification predictions are independent of each other", {
@@ -475,9 +475,9 @@ test_that("Single row predictions work for RF regression", {
   # Get prediction
   rfOutDf1 <- rfD1$getOutDf()
   
-  # Check that dimensions of prediction dataframe are correct
-  expect_equal(dim(rfOutDf1)[1], 1)
-  expect_equal(dim(rfOutDf1)[2], 8)
+  # Check that a prediction is made
+  expect_equal(rfD1$id[1], 9001)
+  expect_is(rfD1$PredictedValueNBR[1], numeric)
 })
 
 test_that("Single row predictions work for lasso regression", {
@@ -504,9 +504,9 @@ test_that("Single row predictions work for lasso regression", {
   # Get prediction
   lassoOutDf1 <- lassoD1$getOutDf()
   
-  # Check that dimensions of prediction dataframe are correct
-  expect_equal(dim(lassoOutDf1)[1], 1)
-  expect_equal(dim(lassoOutDf1)[2], 8)
+  # Check that a prediction is made
+  expect_equal(lassoOutDf1$id[1], 9001)
+  expect_is(lassoOutDf1$PredictedValueNBR[1], numeric)
 })
 
 test_that("RF regression predictions are independent of each other", {
@@ -796,9 +796,9 @@ test_that("Single row predictions work for LMM classification", {
   # Get prediction
   LMMOutDf1 <- LMMD1$getOutDf()
   
-  # Check that dimensions of prediction dataframe are correct
-  expect_equal(dim(LMMOutDf1)[1], 1)
-  expect_equal(dim(LMMOutDf1)[2], 8)
+  # Check that a prediction is made
+  expect_equal(LMMOutDf1$id[1], 9001)
+  expect_is(LMMOutDf1$PredictedProbNBR[1], numeric)
 })
 
 test_that("LMM classification predictions are independent of each other", {

--- a/tests/testthat/test-factor-level-coercion.R
+++ b/tests/testthat/test-factor-level-coercion.R
@@ -1,0 +1,129 @@
+context("Checking factor level coercion is working")
+
+# set seed for reproducibility
+set.seed(7)
+
+# build hot dog set
+n = 300
+df <- data.frame(id = 1:n,
+                 length = rnorm(n, mean = 7, sd = 2),
+                 diameter = rnorm(n, mean = 2, sd = 0.5), 
+                 heat = sample(c("Cold", "Hot"), size = n, replace = T),
+                 condiment = sample(c("Ketchup", "Mustard", "Wasabi", "Syrup"), 
+                                    size = n, replace = T)
+                 )
+
+# give hotdog likeliness score
+df['temp'] <- df['length'] - 2*df['diameter'] - 1
+df$temp[df['heat'] == "Hot"]  = df$temp[df['heat'] == "Hot"] + 1
+df$temp[df['heat'] == "Cold"]  = df$temp[df['heat'] == "Cold"] - 1
+df$temp[df['condiment'] == "Ketchup"] <- df$temp[df['condiment'] == "Ketchup"] + 1
+df$temp[df['condiment'] == "Mustard"] <- df$temp[df['condiment'] == "Mustard"] + 2
+df$temp[df['condiment'] == "Wasabi"] <- df$temp[df['condiment'] == "Wasabi"] - 1
+df$temp[df['condiment'] == "Syrup"] <- df$temp[df['condiment'] == "Syrup"] - 4
+
+# assign response variable
+df["isHotDog"] <- ifelse(df["temp"] > 0, "Y", "N")
+df$temp <- NULL
+
+# swap response variable for 5 percent of data
+noise <- sample(1:n, size = round(n/20), replace = F)
+df$isHotDog[noise] <- ifelse(df$isHotDog[noise] == "Y", "N", "Y")
+df$isHotDog <- as.character(df$isHotDog)
+
+p <- SupervisedModelDevelopmentParams$new()
+p$df <- df
+p$type <- "classification"
+p$impute <- TRUE
+p$grainCol <- "id"
+p$predictedCol <- "isHotDog"
+p$debug <- FALSE
+p$cores <- 1
+
+# Run RandomForest
+RandomForest <- RandomForestDevelopment$new(p)
+RandomForest$run()
+# Run Lasso
+Lasso <- LassoDevelopment$new(p)
+Lasso$run()
+
+# reset seed
+set.seed(NULL)
+
+
+test_that("Single row predictions work", {
+  #
+  dfDeploy1 <- data.frame(id = 9001,
+                          length = 6,
+                          diameter = 3,
+                          heat = "Cold",
+                          condiment = "Syrup")
+  dfDeploy1
+  str(dfDeploy1)
+  
+  p1 <- SupervisedModelDeploymentParams$new()
+  p1$type <- "classification"
+  p1$df <- dfDeploy1
+  p1$grainCol <- "id"
+  p1$predictedCol <- "isHotDog"
+  p1$impute <- TRUE
+  p1$debug <- T
+  p1$cores <- 1
+  
+  rfD1 <- RandomForestDeployment$new(p1)
+  rfD1$deploy()
+  
+  rfOutDf1 <- rfD1$getOutDf()
+  rfOutDf1
+  
+  # Check that dimensions of prediction dataframe are correct
+  expect_equal(dim(rfOutDf1)[1], 1)
+  expect_equal(dim(rfOutDf1)[2], 8)
+})
+
+test_that("Predictions are independent of each other", {
+  #
+  dfDeploy2 <- data.frame(id = c(9001, 9002),
+                          length = c(6, 2),
+                          diameter = c(3, 2), 
+                          heat = c("Cold", "Hot"),
+                          condiment = c("Syrup", "Mustard"))
+  dfDeploy2
+  str(dfDeploy2)
+  
+  p2 <- SupervisedModelDeploymentParams$new()
+  p2$type <- "classification"
+  p2$df <- dfDeploy2
+  p2$grainCol <- "id"
+  p2$predictedCol <- "isHotDog"
+  p2$impute <- TRUE
+  p2$debug <- F
+  p2$cores <- 1
+  
+  rfD2 <- RandomForestDeployment$new(p2)
+  rfD2$deploy()
+  
+  rfOutDf2 <- rfD2$getOutDf()
+  rfOutDf2
+  
+  lassoD2 <- LassoDeployment$new(p2)
+  lassoD2$deploy()
+  
+  lassoOutDf2 <- lassoD2$getOutDf()
+  lassoOutDf2
+  
+  # Check that the prediction is unchanged when the row is embedded in a 
+  # larger data frame
+  expect_equal(rfOutDf1[1, ]$PredictedProbNBR, rfOutDf2[1, ]$PredictedProbNBR)
+})
+
+test_that("Extra factors", {
+  
+})
+
+dfDeploy1 <- data.frame(PatientEncounterID = 2001,
+                        SystolicBPNBR = round(rnorm(n, mean = 150, sd = 15)),
+                        LDLNBR = round(rnorm(n, mean = 180, sd = 30)), 
+                        A1CNBR = round(rnorm(n, mean = 5, sd = 2.5), digits = 1),
+                        GenderFLG = c('F'))
+dfDeploy1

--- a/tests/testthat/test-factor-level-coercion.R
+++ b/tests/testthat/test-factor-level-coercion.R
@@ -42,24 +42,22 @@ p$cores <- 1
 
 # Run RandomForest
 RandomForest <- RandomForestDevelopment$new(p)
-RandomForest$run()
+capture.output(RandomForest$run())
 # Run Lasso
 Lasso <- LassoDevelopment$new(p)
-Lasso$run()
+capture.output(Lasso$run())
 
 # reset seed
 set.seed(NULL)
 
 
-test_that("Single row predictions work", {
+test_that("Single row predictions work for RF", {
   #
   dfDeploy1 <- data.frame(id = 9001,
                           length = 6,
                           diameter = 3,
                           heat = "Cold",
                           condiment = "Syrup")
-  dfDeploy1
-  str(dfDeploy1)
   
   p1 <- SupervisedModelDeploymentParams$new()
   p1$type <- "classification"
@@ -67,7 +65,7 @@ test_that("Single row predictions work", {
   p1$grainCol <- "id"
   p1$predictedCol <- "isHotDog"
   p1$impute <- TRUE
-  p1$debug <- T
+  p1$debug <- F
   p1$cores <- 1
   
   rfD1 <- RandomForestDeployment$new(p1)
@@ -81,15 +79,28 @@ test_that("Single row predictions work", {
   expect_equal(dim(rfOutDf1)[2], 8)
 })
 
-test_that("Predictions are independent of each other", {
+
+test_that("Single row predictions work for lasso", {
+  #
+  lassoD1 <- LassoDeployment$new(p1)
+  lassoD1$deploy()
+  
+  lassoOutDf1 <- lassoD1$getOutDf()
+  lassoOutDf1
+  
+  # Check that dimensions of prediction dataframe are correct
+  expect_equal(dim(lassoOutDf1)[1], 1)
+  expect_equal(dim(lassoOutDf1)[2], 8)
+})
+
+
+test_that("RF predictions are independent of each other", {
   #
   dfDeploy2 <- data.frame(id = c(9001, 9002),
                           length = c(6, 2),
                           diameter = c(3, 2), 
                           heat = c("Cold", "Hot"),
                           condiment = c("Syrup", "Mustard"))
-  dfDeploy2
-  str(dfDeploy2)
   
   p2 <- SupervisedModelDeploymentParams$new()
   p2$type <- "classification"
@@ -117,13 +128,22 @@ test_that("Predictions are independent of each other", {
   expect_equal(rfOutDf1[1, ]$PredictedProbNBR, rfOutDf2[1, ]$PredictedProbNBR)
 })
 
+
+test_that("Lasso predictions are independent of each other", {
+  #
+  
+  lassoD2 <- LassoDeployment$new(p2)
+  lassoD2$deploy()
+  
+  lassoOutDf2 <- lassoD2$getOutDf()
+  lassoOutDf2
+  
+  # Check that the prediction is unchanged when the row is embedded in a 
+  # larger data frame
+  expect_equal(lassoOutDf1[1, ]$PredictedProbNBR, lassoOutDf2[1, ]$PredictedProbNBR)
+})
+
+
 test_that("Extra factors", {
   
 })
-
-dfDeploy1 <- data.frame(PatientEncounterID = 2001,
-                        SystolicBPNBR = round(rnorm(n, mean = 150, sd = 15)),
-                        LDLNBR = round(rnorm(n, mean = 180, sd = 30)), 
-                        A1CNBR = round(rnorm(n, mean = 5, sd = 2.5), digits = 1),
-                        GenderFLG = c('F'))
-dfDeploy1

--- a/tests/testthat/test-factor-level-coercion.R
+++ b/tests/testthat/test-factor-level-coercion.R
@@ -73,12 +73,6 @@ pR$predictedCol <- "hotDogScore"
 pR$debug <- FALSE
 pR$cores <- 1
 
-# Run regression models
-RandomForestR <- RandomForestDevelopment$new(pR)
-capture.output(RandomForestR$run())
-LassoR <- LassoDevelopment$new(pR)
-capture.output(LassoR$run())
-
 # Classification data set
 dfC <- df
 # assign response variable
@@ -96,12 +90,6 @@ pC$grainCol <- "id"
 pC$predictedCol <- "isHotDog"
 pC$debug <- FALSE
 pC$cores <- 1
-
-# Run classification models
-RandomForestC <- RandomForestDevelopment$new(pC)
-capture.output(RandomForestC$run())
-LassoC <- LassoDevelopment$new(pC)
-capture.output(LassoC$run())
 
 # LMM data set
 dfLMM <- df
@@ -125,14 +113,17 @@ pL$predictedCol <- "isHotDog"
 pL$debug <- FALSE
 pL$cores <- 1
 
-# Run LMM models
-LMM <- LinearMixedModelDevelopment$new(pL)
-capture.output(LMM$run())
-
 # reset seed
 set.seed(NULL)
 
-#### BEGIN TESTS ####
+#### DEVELOP CLASSIFICATION MODELS ####
+
+set.seed(7)
+RandomForestC <- RandomForestDevelopment$new(pC)
+capture.output(RandomForestC$run())
+LassoC <- LassoDevelopment$new(pC)
+capture.output(LassoC$run())
+set.seed(NULL)
 
 #### CLASSIFICATION TESTS ####
 
@@ -496,6 +487,17 @@ test_that("Extra factors are imputed correctly for lasso classification (2 colum
 # p5$cores <- 1
 
 
+#### DEVELOP REGRESSION MODELS ####
+# Need to develop regression models after classification tests.  Otherwise
+# the model will be overwritten (only saves one rf model and one lasso model at 
+# a time)
+set.seed(7)
+RandomForestR <- RandomForestDevelopment$new(pR)
+capture.output(RandomForestR$run())
+LassoR <- LassoDevelopment$new(pR)
+capture.output(LassoR$run())
+set.seed(NULL)
+
 #### REGRESSION TESTS ####
 
 test_that("Single row predictions work for RF regression", {
@@ -856,6 +858,12 @@ test_that("Extra factors are imputed correctly for lasso regression (2 columns)"
 # p5$impute <- TRUE
 # p5$debug <- F
 # p5$cores <- 1
+
+#### DEVELOP LMM CLASSIFICATION MODEL ####
+set.seed(7)
+LMM <- LinearMixedModelDevelopment$new(pL)
+capture.output(LMM$run())
+set.seed(NULL)
 
 #### LMM TESTS ####
 

--- a/tests/testthat/test-factor-level-coercion.R
+++ b/tests/testthat/test-factor-level-coercion.R
@@ -162,7 +162,7 @@ test_that("Single row predictions work for RF classification", {
   
   # Check that a prediction is made
   expect_equal(rfOutDf1$id[1], 9001)
-  expect_is(rfOutDf1$PredictedProbNBR[1], numeric)
+  expect_is(rfOutDf1$PredictedProbNBR[1], "numeric")
 })
 
 test_that("Single row predictions work for lasso classification", {
@@ -191,7 +191,7 @@ test_that("Single row predictions work for lasso classification", {
   
   # Check that a prediction is made
   expect_equal(lassoOutDf1$id[1], 9001)
-  expect_is(lassoOutDf1$PredictedProbNBR[1], numeric)
+  expect_is(lassoOutDf1$PredictedProbNBR[1], "numeric")
 })
 
 test_that("RF classification predictions are independent of each other", {
@@ -508,7 +508,7 @@ test_that("Single row predictions work for RF regression", {
   
   p1 <- SupervisedModelDeploymentParams$new()
   p1$type <- "regression"
-  p1$df <- dfDeploy1
+  p1$df <- dfDeploy1R
   p1$grainCol <- "id"
   p1$predictedCol <- "hotDogScore"
   p1$impute <- TRUE
@@ -523,8 +523,8 @@ test_that("Single row predictions work for RF regression", {
   rfOutDf1 <- rfD1$getOutDf()
   
   # Check that a prediction is made
-  expect_equal(rfD1$id[1], 9001)
-  expect_is(rfD1$PredictedValueNBR[1], numeric)
+  expect_equal(rfOutDf1$id[1], 9001)
+  expect_is(rfOutDf1$PredictedValueNBR[1], "numeric")
 })
 
 test_that("Single row predictions work for lasso regression", {
@@ -553,7 +553,7 @@ test_that("Single row predictions work for lasso regression", {
   
   # Check that a prediction is made
   expect_equal(lassoOutDf1$id[1], 9001)
-  expect_is(lassoOutDf1$PredictedValueNBR[1], numeric)
+  expect_is(lassoOutDf1$PredictedValueNBR[1], "numeric")
 })
 
 test_that("RF regression predictions are independent of each other", {
@@ -887,7 +887,7 @@ test_that("Single row predictions work for LMM classification", {
   
   # Check that a prediction is made
   expect_equal(LMMOutDf1$id[1], 9001)
-  expect_is(LMMOutDf1$PredictedProbNBR[1], numeric)
+  expect_is(LMMOutDf1$PredictedProbNBR[1], "numeric")
 })
 
 test_that("LMM classification predictions are independent of each other", {

--- a/tests/testthat/test-factor-level-coercion.R
+++ b/tests/testthat/test-factor-level-coercion.R
@@ -227,6 +227,20 @@ test_that("RF classification predictions are independent of each other", {
   p2$debug <- F
   p2$cores <- 1
   
+  # Full develop data set with 1 new row
+  dfC2 <- dfC
+  dfC2$isHotDog <- NULL
+  dfFull <- rbind(dfDeploy1, dfC2)
+  
+  pF <- SupervisedModelDeploymentParams$new()
+  pF$type <- "classification"
+  pF$df <- dfFull
+  pF$grainCol <- "id"
+  pF$predictedCol <- "isHotDog"
+  pF$impute <- TRUE
+  pF$debug <- F
+  pF$cores <- 1
+  
   # Deploy rf on single row
   capture.output(rfD1 <- RandomForestDeployment$new(p1))
   rfD1$deploy()
@@ -239,8 +253,15 @@ test_that("RF classification predictions are independent of each other", {
   
   rfOutDf2 <- rfD2$getOutDf()
   
+  # Deploy rf on full develop set plus single new row
+  capture.output(rfDFull <- RandomForestDeployment$new(pF))
+  rfDFull$deploy()
+  
+  rfOutDfFull <- rfDFull$getOutDf()
+  
   # Check that the predictions are the same
   expect_equal(rfOutDf1[1, ]$PredictedProbNBR, rfOutDf2[1, ]$PredictedProbNBR)
+  expect_equal(rfOutDf1[1, ]$PredictedProbNBR, rfOutDfFull[1, ]$PredictedProbNBR)
 })
 
 test_that("Lasso classification predictions are independent of each other", {
@@ -276,6 +297,20 @@ test_that("Lasso classification predictions are independent of each other", {
   p2$debug <- F
   p2$cores <- 1
   
+  # Full develop data set with 1 new row
+  dfC2 <- dfC
+  dfC2$isHotDog <- NULL
+  dfFull <- rbind(dfDeploy1, dfC2)
+  
+  pF <- SupervisedModelDeploymentParams$new()
+  pF$type <- "classification"
+  pF$df <- dfFull
+  pF$grainCol <- "id"
+  pF$predictedCol <- "isHotDog"
+  pF$impute <- TRUE
+  pF$debug <- F
+  pF$cores <- 1
+  
   # Deploy lasso on single row
   capture.output(lassoD1 <- LassoDeployment$new(p1))
   lassoD1$deploy()
@@ -288,8 +323,15 @@ test_that("Lasso classification predictions are independent of each other", {
   
   lassoOutDf2 <- lassoD2$getOutDf()
   
+  # Deploy lasso on full develop set plus single new row
+  capture.output(lassoDFull <- LassoDeployment$new(pF))
+  lassoDFull$deploy()
+  
+  lassoOutDfFull <- lassoDFull$getOutDf()
+  
   # Check that the predictions are the same
   expect_equal(lassoOutDf1[1, ]$PredictedProbNBR, lassoOutDf2[1, ]$PredictedProbNBR)
+  expect_equal(lassoOutDf1[1, ]$PredictedProbNBR, lassoOutDfFull[1, ]$PredictedProbNBR)
 })
 
 test_that("Extra factors are imputed correctly for rf classification (1 column)", {
@@ -547,6 +589,20 @@ test_that("RF regression predictions are independent of each other", {
   p2$debug <- F
   p2$cores <- 1
   
+  # Full develop data set with 1 new row
+  dfR2 <- dfR
+  dfR2$hotDogScore <- NULL
+  dfFull <- rbind(dfDeploy1, dfR2)
+  
+  pF <- SupervisedModelDeploymentParams$new()
+  pF$type <- "regression"
+  pF$df <- dfFull
+  pF$grainCol <- "id"
+  pF$predictedCol <- "hotDogScore"
+  pF$impute <- TRUE
+  pF$debug <- F
+  pF$cores <- 1
+  
   # Deploy rf on single row
   capture.output(rfD1 <- RandomForestDeployment$new(p1))
   rfD1$deploy()
@@ -559,8 +615,15 @@ test_that("RF regression predictions are independent of each other", {
   
   rfOutDf2 <- rfD2$getOutDf()
   
+  # Deploy rf on full develop set plus single new row
+  capture.output(rfDFull <- RandomForestDeployment$new(pF))
+  rfDFull$deploy()
+  
+  rfOutDfFull <- rfDFull$getOutDf()
+  
   # Check that the predictions are the same
   expect_equal(rfOutDf1[1, ]$PredictedValueNBR, rfOutDf2[1, ]$PredictedValueNBR)
+  expect_equal(rfOutDf1[1, ]$PredictedValueNBR, rfOutDfFull[1, ]$PredictedValueNBR)
 })
 
 test_that("Lasso regression predictions are independent of each other", {
@@ -596,6 +659,20 @@ test_that("Lasso regression predictions are independent of each other", {
   p2$debug <- F
   p2$cores <- 1
   
+  # Full develop data set with 1 new row
+  dfR2 <- dfR
+  dfR2$hotDogScore <- NULL
+  dfFull <- rbind(dfDeploy1, dfR2)
+  
+  pF <- SupervisedModelDeploymentParams$new()
+  pF$type <- "regression"
+  pF$df <- dfFull
+  pF$grainCol <- "id"
+  pF$predictedCol <- "hotDogScore"
+  pF$impute <- TRUE
+  pF$debug <- F
+  pF$cores <- 1
+  
   # Deploy lasso on single row
   capture.output(lassoD1 <- LassoDeployment$new(p1))
   lassoD1$deploy()
@@ -608,8 +685,15 @@ test_that("Lasso regression predictions are independent of each other", {
   
   lassoOutDf2 <- lassoD2$getOutDf()
   
+  # Deploy lasso on full develop set plus single new row
+  capture.output(lassoDFull <- LassoDeployment$new(pF))
+  lassoDFull$deploy()
+  
+  lassoOutDfFull <- lassoDFull$getOutDf()
+  
   # Check that the predictions are the same
   expect_equal(lassoOutDf1[1, ]$PredictedValueNBR, lassoOutDf2[1, ]$PredictedValueNBR)
+  expect_equal(lassoOutDf1[1, ]$PredictedValueNBR, lassoOutDfFull[1, ]$PredictedValueNBR)
 })
 
 test_that("Extra factors are imputed correctly for rf regression (1 column)", {
@@ -843,6 +927,21 @@ test_that("LMM classification predictions are independent of each other", {
   p2$debug <- F
   p2$cores <- 1
   
+  # Full develop data set with 1 new row
+  dfLMM2 <- dfLMM
+  dfLMM2$isHotDog <- NULL
+  dfFull <- rbind(dfDeploy1, dfLMM2)
+  
+  pF <- SupervisedModelDeploymentParams$new()
+  pF$type <- "classification"
+  pF$df <- dfFull
+  pF$grainCol <- "id"
+  pF$personCol <- "vendorID"
+  pF$predictedCol <- "isHotDog"
+  pF$impute <- TRUE
+  pF$debug <- F
+  pF$cores <- 1
+  
   # Deploy LMM on single row
   capture.output(LMMD1 <- LinearMixedModelDeployment$new(p1))
   LMMD1$deploy()
@@ -855,8 +954,15 @@ test_that("LMM classification predictions are independent of each other", {
   
   LMMOutDf2 <- LMMD2$getOutDf()
   
+  # Deploy lasso on full develop set plus single new row
+  capture.output(LMMDFull <- LinearMixedModelDeployment$new(pF))
+  LMMDFull$deploy()
+  
+  LMMOutDfFull <- LMMDFull$getOutDf()
+  
   # Check that the predictions are the same
   expect_equal(LMMOutDf1[1, ]$PredictedProbNBR, LMMOutDf2[1, ]$PredictedProbNBR)
+  expect_equal(LMMOutDf1[1, ]$PredictedProbNBR, LMMOutDfFull[1, ]$PredictedProbNBR)
 })
 
 test_that("Extra factors are imputed correctly for LMM classification (1 column)", {

--- a/tests/testthat/test-factor-level-coercion.R
+++ b/tests/testthat/test-factor-level-coercion.R
@@ -99,7 +99,7 @@ p3$impute <- TRUE
 p3$debug <- F
 p3$cores <- 1
 
-# Data set with new factor level in one column
+# Data set with new factor levels in two columns
 # Need last row for imputation
 dfDeploy4 <- data.frame(id = c(9006, 9007, 9008, 9009),
                         length = c(5, 5, 5, 5),
@@ -229,4 +229,24 @@ test_that("Extra factors are imputed correctly for rf (2 columns)", {
   # Check that new value is treated as NA
   expect_equal(rfOutDf4[1, ]$PredictedProbNBR, rfOutDf4[3, ]$PredictedProbNBR)
   expect_equal(rfOutDf4[2, ]$PredictedProbNBR, rfOutDf4[3, ]$PredictedProbNBR)
+})
+
+test_that("Extra factors are imputed correctly for lasso (2 columns)", {
+  # Deploy on 3 rows, which should yield the same predictions
+  capture.output(lassoD4 <- LassoDeployment$new(p4))
+  
+  # Check that a warning reporting new factor levels is triggered
+  # Use regular expression to deal with weird quote issues
+  expect_warning(lassoD4$deploy(), 
+                 regex = paste("New categorical variable levels were found:\n",
+                               " -  heat : .{3}Caliente.{4}Lukewarm.{2}\n",
+                               " -  condiment : .{3}Chili.{4}Fudge.{2}\n", 
+                               "These values have been set to NA.",
+                               sep = ""))
+  
+  lassoOutDf4 <- lassoD4$getOutDf()
+  
+  # Check that new value is treated as NA
+  expect_equal(lassoOutDf4[1, ]$PredictedProbNBR, lassoOutDf4[3, ]$PredictedProbNBR)
+  expect_equal(lassoOutDf4[2, ]$PredictedProbNBR, lassoOutDf4[3, ]$PredictedProbNBR)
 })

--- a/tests/testthat/test-factor-level-coercion.R
+++ b/tests/testthat/test-factor-level-coercion.R
@@ -1,3 +1,30 @@
+# The purpose of these unit tests it to check that factor levels from develop 
+# are being correctly applied to the deploy data, allowing for single row (and
+# other small deploy data set) predictions.
+#
+# Several tests are performed for each of lasso and random forest (both 
+# classification and regression) and LMM (just classification).  These are
+#
+# 1. Check that single row predictions work
+#    - build single row deploy data frame and check that deploy outputs a
+#      prediction
+#
+# 2. Check that predictions are independent
+#    - build a single row deploy data set, a 2 row data set, and a data set
+#      containing all of the training data, all of which share the same first
+#      row
+#    - check that the predictions are the same on all three data sets for the
+#      shared row (i.e. the values taken in other rows of the data have no 
+#      effect on the prediction)
+#
+# 3. Check new factor levels are dealt with correctly
+#    - build data sets with new factor levels not seen in develop
+#    - check that the correct warning is raised
+#    - check that these new levels are treated as NA by comparing the
+#      prediction to a prediction made on data with NAs instead of the new 
+#      factor levels
+#    - tests are preformed with new factor levels in 1 column and in 2 columns
+
 context("Checking factor level coercion is working")
 
 # set seed for reproducibility

--- a/tests/testthat/test-factor-level-coercion.R
+++ b/tests/testthat/test-factor-level-coercion.R
@@ -183,8 +183,11 @@ test_that("Extra factors are imputed correctly for rf (1 column)", {
   capture.output(rfD3 <- RandomForestDeployment$new(p3))
   
   # Check that a warning reporting new factor levels is triggered
-  # TODO: specify warning text
-  expect_warning(rfD3$deploy())
+  expect_warning(rfD3$deploy(), 
+                 paste("New categorical variable levels were found:\n",
+                       " -  heat : Frozen\n",
+                       "These values have been set to NA.",
+                       sep = ""))
   
   rfOutDf3 <- rfD3$getOutDf()
   
@@ -195,10 +198,13 @@ test_that("Extra factors are imputed correctly for rf (1 column)", {
 test_that("Extra factors are imputed correctly for lasso  (1 column)", {
   # Deploy on 3 rows, which should yield the same predictions
   capture.output(lassoD3 <- LassoDeployment$new(p3))
-  expect_warning(lassoD3$deploy())
-  
   # Check that a warning reporting new factor levels is triggered
-  # TODO: specify warning text
+  expect_warning(lassoD3$deploy(), 
+                 paste("New categorical variable levels were found:\n",
+                       " -  heat : Frozen\n",
+                       "These values have been set to NA.",
+                       sep = ""))
+  
   lassoOutDf3 <- lassoD3$getOutDf()
   
   # Check that new value is treated as NA
@@ -210,11 +216,13 @@ test_that("Extra factors are imputed correctly for rf (2 columns)", {
   capture.output(rfD4 <- RandomForestDeployment$new(p4))
   
   # Check that a warning reporting new factor levels is triggered
-  # TODO: specify warning text
-  expect_warning(rfD4$deploy())
-  
-  rfD4 <- RandomForestDeployment$new(p4)
-  rfD4$deploy()
+  # Use regular expression to deal with weird quote issues
+  expect_warning(rfD4$deploy(), 
+                 regex = paste("New categorical variable levels were found:\n",
+                               " -  heat : .{3}Caliente.{4}Lukewarm.{2}\n",
+                               " -  condiment : .{3}Chili.{4}Fudge.{2}\n", 
+                               "These values have been set to NA.",
+                               sep = ""))
   
   rfOutDf4 <- rfD4$getOutDf()
   

--- a/tests/testthat/test-factor-level-coercion.R
+++ b/tests/testthat/test-factor-level-coercion.R
@@ -116,6 +116,22 @@ p4$impute <- TRUE
 p4$debug <- F
 p4$cores <- 1
 
+# Single row data set with NAs
+dfDeploy5 <- data.frame(id = 9010,
+                        length = 8,
+                        diameter = NA, 
+                        heat = "Hot",
+                        condiment = "NA")
+
+p5 <- SupervisedModelDeploymentParams$new()
+p5$type <- "classification"
+p5$df <- dfDeploy5
+p5$grainCol <- "id"
+p5$predictedCol <- "isHotDog"
+p5$impute <- TRUE
+p5$debug <- F
+p5$cores <- 1
+
 #### BEGIN TESTS ####
 
 test_that("Single row predictions work for RF", {
@@ -250,3 +266,8 @@ test_that("Extra factors are imputed correctly for lasso (2 columns)", {
   expect_equal(lassoOutDf4[1, ]$PredictedProbNBR, lassoOutDf4[3, ]$PredictedProbNBR)
   expect_equal(lassoOutDf4[2, ]$PredictedProbNBR, lassoOutDf4[3, ]$PredictedProbNBR)
 })
+
+# TODO: make test for single row predictions when data contains NAs
+# Currently, imputation is done using the deployset so will fail if there is 
+# only one row
+

--- a/tests/testthat/test-factor-level-coercion.R
+++ b/tests/testthat/test-factor-level-coercion.R
@@ -8,6 +8,9 @@
 # 1. Check that single row predictions work
 #    - build single row deploy data frame and check that deploy outputs a
 #      prediction
+#    - note that this implicitly tests that predictions can be made when there
+#      are missing factors in one or more columns (for a single row, all but 
+#      one level of each factor will be missing)
 #
 # 2. Check that predictions are independent
 #    - build a single row deploy data set, a 2 row data set, and a data set
@@ -23,7 +26,9 @@
 #    - check that these new levels are treated as NA by comparing the
 #      prediction to a prediction made on data with NAs instead of the new 
 #      factor levels
-#    - tests are preformed with new factor levels in 1 column and in 2 columns
+#    - in one test, a single new factor level is introduced in a single column
+#    - in a separate test, multiple new factor levels are introduced in two 
+#      separate columns
 
 context("Checking factor level coercion is working")
 

--- a/tests/testthat/test-factor-level-coercion.R
+++ b/tests/testthat/test-factor-level-coercion.R
@@ -508,7 +508,7 @@ test_that("Single row predictions work for RF regression", {
   
   p1 <- SupervisedModelDeploymentParams$new()
   p1$type <- "regression"
-  p1$df <- dfDeploy1R
+  p1$df <- dfDeploy1
   p1$grainCol <- "id"
   p1$predictedCol <- "hotDogScore"
   p1$impute <- TRUE

--- a/tests/testthat/test-factor-level-coercion.R
+++ b/tests/testthat/test-factor-level-coercion.R
@@ -3,36 +3,59 @@ context("Checking factor level coercion is working")
 # set seed for reproducibility
 set.seed(7)
 
-#### SHARED CLASSIFICATION STUFF ####
-
 # build hot dog set
 n = 300
-dfC <- data.frame(id = 1:n,
-                  length = rnorm(n, mean = 7, sd = 2),
-                  diameter = rnorm(n, mean = 2, sd = 0.5), 
-                  heat = sample(c("Cold", "Hot"), size = n, replace = T),
-                  condiment = sample(c("Ketchup", "Mustard", "Wasabi", "Syrup"), 
-                                     size = n, replace = T)
-                  )
+df <- data.frame(id = 1:n,
+                 vendorID = sample(1:9, size = n, replace = T),
+                 length = rnorm(n, mean = 7, sd = 2),
+                 diameter = rnorm(n, mean = 2, sd = 0.5), 
+                 heat = sample(c("Cold", "Hot"), size = n, replace = T),
+                 condiment = sample(c("Ketchup", "Mustard", "Wasabi", "Syrup"), 
+                                    size = n, replace = T)
+                 )
 
 # give hotdog likeliness score
-dfC['temp'] <- dfC['length'] - 2*dfC['diameter'] - 1
-dfC$temp[dfC['heat'] == "Hot"]  = dfC$temp[dfC['heat'] == "Hot"] + 1
-dfC$temp[dfC['heat'] == "Cold"]  = dfC$temp[dfC['heat'] == "Cold"] - 1
-dfC$temp[dfC['condiment'] == "Ketchup"] <- dfC$temp[dfC['condiment'] == "Ketchup"] + 1
-dfC$temp[dfC['condiment'] == "Mustard"] <- dfC$temp[dfC['condiment'] == "Mustard"] + 2
-dfC$temp[dfC['condiment'] == "Wasabi"] <- dfC$temp[dfC['condiment'] == "Wasabi"] - 1
-dfC$temp[dfC['condiment'] == "Syrup"] <- dfC$temp[dfC['condiment'] == "Syrup"] - 4
+df['hotDogScore'] <- df['length'] - 2*df['diameter'] - 1
+df$hotDogScore[df['heat'] == "Hot"]  = df$hotDogScore[df['heat'] == "Hot"] + 1
+df$hotDogScore[df['heat'] == "Cold"]  = df$hotDogScore[df['heat'] == "Cold"] - 1
+df$hotDogScore[df['condiment'] == "Ketchup"] <- df$hotDogScore[df['condiment'] == "Ketchup"] + 1
+df$hotDogScore[df['condiment'] == "Mustard"] <- df$hotDogScore[df['condiment'] == "Mustard"] + 2
+df$hotDogScore[df['condiment'] == "Wasabi"] <- df$hotDogScore[df['condiment'] == "Wasabi"] - 1
+df$hotDogScore[df['condiment'] == "Syrup"] <- df$hotDogScore[df['condiment'] == "Syrup"] - 4
 
+# Add noise
+df$hotDogScore <- df$hotDogScore + rnorm(n, mean = 0, sd = 1.25)
+
+# Regression data set
+dfR <- df
+dfR$isHotDog <- NULL
+dfR$vendorID <- NULL
+
+# Set parameters for regression models
+pR <- SupervisedModelDevelopmentParams$new()
+pR$df <- dfR
+pR$type <- "regression"
+pR$impute <- TRUE
+pR$grainCol <- "id"
+pR$predictedCol <- "hotDogScore"
+pR$debug <- FALSE
+pR$cores <- 1
+
+# Run regression models
+RandomForestR <- RandomForestDevelopment$new(pR)
+capture.output(RandomForestR$run())
+LassoR <- LassoDevelopment$new(pR)
+capture.output(LassoR$run())
+
+# Classification data set
+dfC <- df
 # assign response variable
-dfC["isHotDog"] <- ifelse(dfC["temp"] > 0, "Y", "N")
-dfC$temp <- NULL
-
-# swap response variable for 5 percent of data
-noise <- sample(1:n, size = round(n/20), replace = F)
-dfC$isHotDog[noise] <- ifelse(dfC$isHotDog[noise] == "Y", "N", "Y")
+dfC["isHotDog"] <- ifelse(dfC["hotDogScore"] > 0, "Y", "N")
 dfC$isHotDog <- as.character(dfC$isHotDog)
+dfC$hotDogScore <- NULL
+dfC$vendorID <- NULL
 
+# Set parameters for classification models
 pC <- SupervisedModelDevelopmentParams$new()
 pC$df <- dfC
 pC$type <- "classification"
@@ -42,16 +65,37 @@ pC$predictedCol <- "isHotDog"
 pC$debug <- FALSE
 pC$cores <- 1
 
-# Run RandomForest
-RandomForest <- RandomForestDevelopment$new(pC)
-capture.output(RandomForest$run())
-# Run Lasso
-Lasso <- LassoDevelopment$new(pC)
-capture.output(Lasso$run())
+# Run classification models
+RandomForestC <- RandomForestDevelopment$new(pC)
+capture.output(RandomForestC$run())
+LassoC <- LassoDevelopment$new(pC)
+capture.output(LassoC$run())
 
-#### SHARED REGRESSION STUFF ####
+# LMM data set
+dfLMM <- df
+# Shift values based on vendorID: higher vendorID -> greater chance of hotdog
+dfLMM$hotDogScore <- dfLMM$hotDogScore + rnorm(n, 
+                                               mean = (dfLMM$vendorID - 5)/2, 
+                                               sd = 0.25)
+# assign response varaible
+dfLMM["isHotDog"] <- ifelse(dfLMM["hotDogScore"] > 0, "Y", "N")
+dfLMM$isHotDog <- as.character(dfLMM$isHotDog)
+dfLMM$hotDogScore <- NULL
 
-#### SHARED LMM STUFF ####
+# Set parameters for LMM
+pL <- SupervisedModelDevelopmentParams$new()
+pL$df <- dfLMM
+pL$type <- "classification"
+pL$impute <- TRUE
+pL$grainCol <- "id"
+pL$personCol <- "vendorID"
+pL$predictedCol <- "isHotDog"
+pL$debug <- FALSE
+pL$cores <- 1
+
+# Run LMM models
+LMM <- LinearMixedModelDevelopment$new(pL)
+capture.output(LMM$run())
 
 # reset seed
 set.seed(NULL)
@@ -60,7 +104,7 @@ set.seed(NULL)
 
 #### CLASSIFICATION TESTS ####
 
-test_that("Single row predictions work for RF", {
+test_that("Single row predictions work for RF classification", {
   # Single row prediction data set
   dfDeploy1 <- data.frame(id = 9001,
                           length = 6,
@@ -89,7 +133,7 @@ test_that("Single row predictions work for RF", {
   expect_equal(dim(rfOutDf1)[2], 8)
 })
 
-test_that("Single row predictions work for lasso", {
+test_that("Single row predictions work for lasso classification", {
   # Single row prediction data set
   dfDeploy1 <- data.frame(id = 9001,
                           length = 6,
@@ -118,7 +162,7 @@ test_that("Single row predictions work for lasso", {
   expect_equal(dim(lassoOutDf1)[2], 8)
 })
 
-test_that("RF predictions are independent of each other", {
+test_that("RF classification predictions are independent of each other", {
   # Single row prediction data set
   dfDeploy1 <- data.frame(id = 9001,
                           length = 6,
@@ -167,7 +211,7 @@ test_that("RF predictions are independent of each other", {
   expect_equal(rfOutDf1[1, ]$PredictedProbNBR, rfOutDf2[1, ]$PredictedProbNBR)
 })
 
-test_that("Lasso predictions are independent of each other", {
+test_that("Lasso classification predictions are independent of each other", {
   # Single row prediction data set
   dfDeploy1 <- data.frame(id = 9001,
                           length = 6,
@@ -216,7 +260,7 @@ test_that("Lasso predictions are independent of each other", {
   expect_equal(lassoOutDf1[1, ]$PredictedProbNBR, lassoOutDf2[1, ]$PredictedProbNBR)
 })
 
-test_that("Extra factors are imputed correctly for rf (1 column)", {
+test_that("Extra factors are imputed correctly for rf classification (1 column)", {
   # Data set with new factor level in one column
   # Need last row for imputation
   dfDeploy3 <- data.frame(id = c(9003, 9004, 9005),
@@ -250,7 +294,7 @@ test_that("Extra factors are imputed correctly for rf (1 column)", {
   expect_equal(rfOutDf3[1, ]$PredictedProbNBR, rfOutDf3[2, ]$PredictedProbNBR)
 })
 
-test_that("Extra factors are imputed correctly for lasso  (1 column)", {
+test_that("Extra factors are imputed correctly for lasso classification  (1 column)", {
   # Data set with new factor level in one column
   # Need last row for imputation
   dfDeploy3 <- data.frame(id = c(9003, 9004, 9005),
@@ -283,7 +327,7 @@ test_that("Extra factors are imputed correctly for lasso  (1 column)", {
   expect_equal(lassoOutDf3[1, ]$PredictedProbNBR, lassoOutDf3[2, ]$PredictedProbNBR)
 })
 
-test_that("Extra factors are imputed correctly for rf (2 columns)", {
+test_that("Extra factors are imputed correctly for rf classification (2 columns)", {
   # Data set with new factor levels in two columns
   # Need last row for imputation
   dfDeploy4 <- data.frame(id = c(9006, 9007, 9008, 9009),
@@ -320,7 +364,7 @@ test_that("Extra factors are imputed correctly for rf (2 columns)", {
   expect_equal(rfOutDf4[2, ]$PredictedProbNBR, rfOutDf4[3, ]$PredictedProbNBR)
 })
 
-test_that("Extra factors are imputed correctly for lasso (2 columns)", {
+test_that("Extra factors are imputed correctly for lasso classification (2 columns)", {
   # Data set with new factor levels in two columns
   # Need last row for imputation
   dfDeploy4 <- data.frame(id = c(9006, 9007, 9008, 9009),
@@ -380,5 +424,503 @@ test_that("Extra factors are imputed correctly for lasso (2 columns)", {
 
 #### REGRESSION TESTS ####
 
+test_that("Single row predictions work for RF regression", {
+  # Single row prediction data set
+  dfDeploy1 <- data.frame(id = 9001,
+                          length = 6,
+                          diameter = 3,
+                          heat = "Cold",
+                          condiment = "Syrup")
+  
+  p1 <- SupervisedModelDeploymentParams$new()
+  p1$type <- "regression"
+  p1$df <- dfDeploy1
+  p1$grainCol <- "id"
+  p1$predictedCol <- "hotDogScore"
+  p1$impute <- TRUE
+  p1$debug <- F
+  p1$cores <- 1
+  
+  # Deploy rf on single row
+  capture.output(rfD1 <- RandomForestDeployment$new(p1))
+  rfD1$deploy()
+  
+  # Get prediction
+  rfOutDf1 <- rfD1$getOutDf()
+  
+  # Check that dimensions of prediction dataframe are correct
+  expect_equal(dim(rfOutDf1)[1], 1)
+  expect_equal(dim(rfOutDf1)[2], 8)
+})
+
+test_that("Single row predictions work for lasso regression", {
+  # Single row prediction data set
+  dfDeploy1 <- data.frame(id = 9001,
+                          length = 6,
+                          diameter = 3,
+                          heat = "Cold",
+                          condiment = "Syrup")
+  
+  p1 <- SupervisedModelDeploymentParams$new()
+  p1$type <- "regression"
+  p1$df <- dfDeploy1
+  p1$grainCol <- "id"
+  p1$predictedCol <- "hotDogScore"
+  p1$impute <- TRUE
+  p1$debug <- F
+  p1$cores <- 1
+  
+  # Deploy lasso on single row
+  capture.output(lassoD1 <- LassoDeployment$new(p1))
+  lassoD1$deploy()
+  
+  # Get prediction
+  lassoOutDf1 <- lassoD1$getOutDf()
+  
+  # Check that dimensions of prediction dataframe are correct
+  expect_equal(dim(lassoOutDf1)[1], 1)
+  expect_equal(dim(lassoOutDf1)[2], 8)
+})
+
+test_that("RF regression predictions are independent of each other", {
+  # Single row prediction data set
+  dfDeploy1 <- data.frame(id = 9001,
+                          length = 6,
+                          diameter = 3,
+                          heat = "Cold",
+                          condiment = "Syrup")
+  
+  p1 <- SupervisedModelDeploymentParams$new()
+  p1$type <- "regression"
+  p1$df <- dfDeploy1
+  p1$grainCol <- "id"
+  p1$predictedCol <- "hotDogScore"
+  p1$impute <- TRUE
+  p1$debug <- F
+  p1$cores <- 1
+  
+  # Two row prediction data set, with first row same as dfDeploy2
+  dfDeploy2 <- data.frame(id = c(9001, 9002),
+                          length = c(6, 2),
+                          diameter = c(3, 2), 
+                          heat = c("Cold", "Hot"),
+                          condiment = c("Syrup", "Mustard"))
+  
+  p2 <- SupervisedModelDeploymentParams$new()
+  p2$type <- "regression"
+  p2$df <- dfDeploy2
+  p2$grainCol <- "id"
+  p2$predictedCol <- "hotDogScore"
+  p2$impute <- TRUE
+  p2$debug <- F
+  p2$cores <- 1
+  
+  # Deploy rf on single row
+  capture.output(rfD1 <- RandomForestDeployment$new(p1))
+  rfD1$deploy()
+  
+  rfOutDf1 <- rfD1$getOutDf()
+  
+  # Deploy rf on 2 rows, one of which is identical to the one above
+  capture.output(rfD2 <- RandomForestDeployment$new(p2))
+  rfD2$deploy()
+  
+  rfOutDf2 <- rfD2$getOutDf()
+  
+  # Check that the predictions are the same
+  expect_equal(rfOutDf1[1, ]$PredictedValueNBR, rfOutDf2[1, ]$PredictedValueNBR)
+})
+
+test_that("Lasso regression predictions are independent of each other", {
+  # Single row prediction data set
+  dfDeploy1 <- data.frame(id = 9001,
+                          length = 6,
+                          diameter = 3,
+                          heat = "Cold",
+                          condiment = "Syrup")
+  
+  p1 <- SupervisedModelDeploymentParams$new()
+  p1$type <- "regression"
+  p1$df <- dfDeploy1
+  p1$grainCol <- "id"
+  p1$predictedCol <- "hotDogScore"
+  p1$impute <- TRUE
+  p1$debug <- F
+  p1$cores <- 1
+  
+  # Two row prediction data set, with first row same as dfDeploy2
+  dfDeploy2 <- data.frame(id = c(9001, 9002),
+                          length = c(6, 2),
+                          diameter = c(3, 2), 
+                          heat = c("Cold", "Hot"),
+                          condiment = c("Syrup", "Mustard"))
+  
+  p2 <- SupervisedModelDeploymentParams$new()
+  p2$type <- "regression"
+  p2$df <- dfDeploy2
+  p2$grainCol <- "id"
+  p2$predictedCol <- "hotDogScore"
+  p2$impute <- TRUE
+  p2$debug <- F
+  p2$cores <- 1
+  
+  # Deploy lasso on single row
+  capture.output(lassoD1 <- LassoDeployment$new(p1))
+  lassoD1$deploy()
+  
+  lassoOutDf1 <- lassoD1$getOutDf()
+  
+  # Deploy lasso on 2 rows, one of which is identical to the one above
+  capture.output(lassoD2 <- LassoDeployment$new(p2))
+  lassoD2$deploy()
+  
+  lassoOutDf2 <- lassoD2$getOutDf()
+  
+  # Check that the predictions are the same
+  expect_equal(lassoOutDf1[1, ]$PredictedValueNBR, lassoOutDf2[1, ]$PredictedValueNBR)
+})
+
+test_that("Extra factors are imputed correctly for rf regression (1 column)", {
+  # Data set with new factor level in one column
+  # Need last row for imputation
+  dfDeploy3 <- data.frame(id = c(9003, 9004, 9005),
+                          length = c(6, 6, 6),
+                          diameter = c(3, 3, 3), 
+                          heat = c("Frozen", NA, "Cold"),
+                          condiment = c("Ketchup", "Ketchup", "Ketchup"))
+  
+  p3 <- SupervisedModelDeploymentParams$new()
+  p3$type <- "regression"
+  p3$df <- dfDeploy3
+  p3$grainCol <- "id"
+  p3$predictedCol <- "hotDogScore"
+  p3$impute <- TRUE
+  p3$debug <- F
+  p3$cores <- 1
+  
+  # Deploy on 3 rows, which should yield the same predictions
+  capture.output(rfD3 <- RandomForestDeployment$new(p3))
+  
+  # Check that a warning reporting new factor levels is triggered
+  expect_warning(rfD3$deploy(), 
+                 paste("New categorical variable levels were found:\n",
+                       " -  heat : Frozen\n",
+                       "These values have been set to NA.",
+                       sep = ""))
+  
+  rfOutDf3 <- rfD3$getOutDf()
+  
+  # Check that new value is treated as NA
+  expect_equal(rfOutDf3[1, ]$PredictedValueNBR, rfOutDf3[2, ]$PredictedValueNBR)
+})
+
+test_that("Extra factors are imputed correctly for lasso regression (1 column)", {
+  # Data set with new factor level in one column
+  # Need last row for imputation
+  dfDeploy3 <- data.frame(id = c(9003, 9004, 9005),
+                          length = c(6, 6, 6),
+                          diameter = c(3, 3, 3), 
+                          heat = c("Frozen", NA, "Cold"),
+                          condiment = c("Ketchup", "Ketchup", "Ketchup"))
+  
+  p3 <- SupervisedModelDeploymentParams$new()
+  p3$type <- "regression"
+  p3$df <- dfDeploy3
+  p3$grainCol <- "id"
+  p3$predictedCol <- "hotDogScore"
+  p3$impute <- TRUE
+  p3$debug <- F
+  p3$cores <- 1
+  
+  # Deploy on 3 rows, which should yield the same predictions
+  capture.output(lassoD3 <- LassoDeployment$new(p3))
+  # Check that a warning reporting new factor levels is triggered
+  expect_warning(lassoD3$deploy(), 
+                 paste("New categorical variable levels were found:\n",
+                       " -  heat : Frozen\n",
+                       "These values have been set to NA.",
+                       sep = ""))
+  
+  lassoOutDf3 <- lassoD3$getOutDf()
+  
+  # Check that new value is treated as NA
+  expect_equal(lassoOutDf3[1, ]$PredictedValueNBR, lassoOutDf3[2, ]$PredictedValueNBR)
+})
+
+test_that("Extra factors are imputed correctly for rf regression (2 columns)", {
+  # Data set with new factor levels in two columns
+  # Need last row for imputation
+  dfDeploy4 <- data.frame(id = c(9006, 9007, 9008, 9009),
+                          length = c(5, 5, 5, 5),
+                          diameter = c(2, 2, 2, 2), 
+                          heat = c("Lukewarm", "Caliente", NA, "Hot"),
+                          condiment = c("Chili", "Fudge", NA, "Wasabi"))
+  
+  p4 <- SupervisedModelDeploymentParams$new()
+  p4$type <- "regression"
+  p4$df <- dfDeploy4
+  p4$grainCol <- "id"
+  p4$predictedCol <- "hotDogScore"
+  p4$impute <- TRUE
+  p4$debug <- F
+  p4$cores <- 1
+  
+  # Deploy on 4 rows, which should yield the same predictions
+  capture.output(rfD4 <- RandomForestDeployment$new(p4))
+  
+  # Check that a warning reporting new factor levels is triggered
+  # Use regular expression to deal with weird quote issues
+  expect_warning(rfD4$deploy(), 
+                 regex = paste("New categorical variable levels were found:\n",
+                               " -  heat : .{3}Caliente.{4}Lukewarm.{2}\n",
+                               " -  condiment : .{3}Chili.{4}Fudge.{2}\n", 
+                               "These values have been set to NA.",
+                               sep = ""))
+  
+  rfOutDf4 <- rfD4$getOutDf()
+  
+  # Check that new value is treated as NA
+  expect_equal(rfOutDf4[1, ]$PredictedValueNBR, rfOutDf4[3, ]$PredictedValueNBR)
+  expect_equal(rfOutDf4[2, ]$PredictedValueNBR, rfOutDf4[3, ]$PredictedValueNBR)
+})
+
+test_that("Extra factors are imputed correctly for lasso regression (2 columns)", {
+  # Data set with new factor levels in two columns
+  # Need last row for imputation
+  dfDeploy4 <- data.frame(id = c(9006, 9007, 9008, 9009),
+                          length = c(5, 5, 5, 5),
+                          diameter = c(2, 2, 2, 2), 
+                          heat = c("Lukewarm", "Caliente", NA, "Hot"),
+                          condiment = c("Chili", "Fudge", NA, "Wasabi"))
+  
+  p4 <- SupervisedModelDeploymentParams$new()
+  p4$type <- "regression"
+  p4$df <- dfDeploy4
+  p4$grainCol <- "id"
+  p4$predictedCol <- "hotDogScore"
+  p4$impute <- TRUE
+  p4$debug <- F
+  p4$cores <- 1
+  
+  # Deploy on 4 rows, which should yield the same predictions
+  capture.output(lassoD4 <- LassoDeployment$new(p4))
+  
+  # Check that a warning reporting new factor levels is triggered
+  # Use regular expression to deal with weird quote issues
+  expect_warning(lassoD4$deploy(), 
+                 regex = paste("New categorical variable levels were found:\n",
+                               " -  heat : .{3}Caliente.{4}Lukewarm.{2}\n",
+                               " -  condiment : .{3}Chili.{4}Fudge.{2}\n", 
+                               "These values have been set to NA.",
+                               sep = ""))
+  
+  lassoOutDf4 <- lassoD4$getOutDf()
+  
+  # Check that new value is treated as NA
+  expect_equal(lassoOutDf4[1, ]$PredictedValueNBR, lassoOutDf4[3, ]$PredictedValueNBR)
+  expect_equal(lassoOutDf4[2, ]$PredictedValueNBR, lassoOutDf4[3, ]$PredictedValueNBR)
+})
+
+# TODO: make test for single row predictions when data contains NAs
+# Currently, imputation is done using the deployset so will fail if there is 
+# only one row
+
+# Single row data set with NAs
+# dfDeploy5 <- data.frame(id = 9010,
+#                         length = 8,
+#                         diameter = NA, 
+#                         heat = "Hot",
+#                         condiment = "NA")
+# 
+# p5 <- SupervisedModelDeploymentParams$new()
+# p5$type <- "regression"
+# p5$df <- dfDeploy5
+# p5$grainCol <- "id"
+# p5$predictedCol <- "hotDogScore"
+# p5$impute <- TRUE
+# p5$debug <- F
+# p5$cores <- 1
+
 #### LMM TESTS ####
 
+test_that("Single row predictions work for LMM classification", {
+  # Single row prediction data set
+  dfDeploy1 <- data.frame(id = 9001,
+                          vendorID = 9,
+                          length = 8,
+                          diameter = 2,
+                          heat = "Cold",
+                          condiment = "Syrup")
+  
+  p1 <- SupervisedModelDeploymentParams$new()
+  p1$type <- "classification"
+  p1$df <- dfDeploy1
+  p1$grainCol <- "id"
+  p1$personCol <- "vendorID"
+  p1$predictedCol <- "isHotDog"
+  p1$impute <- TRUE
+  p1$debug <- F
+  p1$cores <- 1
+  
+  # Deploy LMM on single row
+  capture.output(LMMD1 <- LinearMixedModelDeployment$new(p1))
+  LMMD1$deploy()
+  
+  # Get prediction
+  LMMOutDf1 <- LMMD1$getOutDf()
+  
+  # Check that dimensions of prediction dataframe are correct
+  expect_equal(dim(LMMOutDf1)[1], 1)
+  expect_equal(dim(LMMOutDf1)[2], 8)
+})
+
+test_that("LMM classification predictions are independent of each other", {
+  # Single row prediction data set
+  dfDeploy1 <- data.frame(id = 9001,
+                          vendorID = 9,
+                          length = 8,
+                          diameter = 2,
+                          heat = "Cold",
+                          condiment = "Syrup")
+  
+  p1 <- SupervisedModelDeploymentParams$new()
+  p1$type <- "classification"
+  p1$df <- dfDeploy1
+  p1$grainCol <- "id"
+  p1$personCol <- "vendorID"
+  p1$predictedCol <- "isHotDog"
+  p1$impute <- TRUE
+  p1$debug <- F
+  p1$cores <- 1
+  
+  # Two row prediction data set, with first row same as dfDeploy2
+  dfDeploy2 <- data.frame(id = c(9001, 9002),
+                          vendorID = c(9, 3), 
+                          length = c(8, 2),
+                          diameter = c(2, 2), 
+                          heat = c("Cold", "Hot"),
+                          condiment = c("Syrup", "Mustard"))
+  
+  p2 <- SupervisedModelDeploymentParams$new()
+  p2$type <- "classification"
+  p2$df <- dfDeploy2
+  p2$grainCol <- "id"
+  p2$personCol <- "vendorID"
+  p2$predictedCol <- "isHotDog"
+  p2$impute <- TRUE
+  p2$debug <- F
+  p2$cores <- 1
+  
+  # Deploy LMM on single row
+  capture.output(LMMD1 <- LinearMixedModelDeployment$new(p1))
+  LMMD1$deploy()
+  
+  LMMOutDf1 <- LMMD1$getOutDf()
+  
+  # Deploy rf on 2 rows, one of which is identical to the one above
+  capture.output(LMMD2 <- LinearMixedModelDeployment$new(p2))
+  LMMD2$deploy()
+  
+  LMMOutDf2 <- LMMD2$getOutDf()
+  
+  # Check that the predictions are the same
+  expect_equal(LMMOutDf1[1, ]$PredictedProbNBR, LMMOutDf2[1, ]$PredictedProbNBR)
+})
+
+test_that("Extra factors are imputed correctly for LMM classification (1 column)", {
+  # Data set with new factor level in one column
+  # Need last row for imputation
+  dfDeploy3 <- data.frame(id = c(9003, 9004, 9005),
+                          vendorID = c(9,9,9),
+                          length = c(8, 8, 8),
+                          diameter = c(2, 2, 2),
+                          heat = c("Frozen", NA, "Cold"),
+                          condiment = c("Ketchup", "Ketchup", "Ketchup"))
+
+  p3 <- SupervisedModelDeploymentParams$new()
+  p3$type <- "classification"
+  p3$df <- dfDeploy3
+  p3$grainCol <- "id"
+  p3$personCol <- "vendorID"
+  p3$predictedCol <- "isHotDog"
+  p3$impute <- TRUE
+  p3$debug <- F
+  p3$cores <- 1
+
+  # Deploy on 3 rows, which should yield the same predictions
+  capture.output(LMMD3 <- LinearMixedModelDeployment$new(p3))
+
+  # Check that a warning reporting new factor levels is triggered
+  expect_warning(LMMD3$deploy(),
+                 paste("New categorical variable levels were found:\n",
+                       " -  heat : Frozen\n",
+                       "These values have been set to NA.",
+                       sep = ""))
+
+  LMMOutDf3 <- LMMD3$getOutDf()
+
+  # Check that new value is treated as NA
+  expect_equal(LMMOutDf3[1, ]$PredictedProbNBR, LMMOutDf3[2, ]$PredictedProbNBR)
+})
+
+test_that("Extra factors are imputed correctly for LMM classification (2 columns)", {
+  # Data set with new factor levels in two columns
+  # Need last row for imputation
+  dfDeploy4 <- data.frame(id = c(9006, 9007, 9008, 9009),
+                          vendorID = c(7, 7, 7, 7),
+                          length = c(5, 5, 5, 5),
+                          diameter = c(2, 2, 2, 2),
+                          heat = c("Lukewarm", "Caliente", NA, "Hot"),
+                          condiment = c("Chili", "Fudge", NA, "Wasabi"))
+
+  p4 <- SupervisedModelDeploymentParams$new()
+  p4$type <- "classification"
+  p4$df <- dfDeploy4
+  p4$grainCol <- "id"
+  p4$personCol <- "vendorID"
+  p4$predictedCol <- "isHotDog"
+  p4$impute <- TRUE
+  p4$debug <- F
+  p4$cores <- 1
+
+  # Deploy on 4 rows, which should yield the same predictions
+  capture.output(LMMD4 <- LinearMixedModelDeployment$new(p4))
+
+  # Check that a warning reporting new factor levels is triggered
+  # Use regular expression to deal with weird quote issues
+  expect_warning(LMMD4$deploy(),
+                 regex = paste("New categorical variable levels were found:\n",
+                               " -  heat : .{3}Caliente.{4}Lukewarm.{2}\n",
+                               " -  condiment : .{3}Chili.{4}Fudge.{2}\n",
+                               "These values have been set to NA.",
+                               sep = ""))
+
+  LMMOutDf4 <- LMMD4$getOutDf()
+
+  # Check that new value is treated as NA
+  expect_equal(LMMOutDf4[1, ]$PredictedProbNBR, LMMOutDf4[3, ]$PredictedProbNBR)
+  expect_equal(LMMOutDf4[2, ]$PredictedProbNBR, LMMOutDf4[3, ]$PredictedProbNBR)
+})
+
+
+# TODO: make test for single row predictions when data contains NAs
+# Currently, imputation is done using the deployset so will fail if there is 
+# only one row
+
+# Single row data set with NAs
+# dfDeploy5 <- data.frame(id = 9010,
+#                         vendorID = 5,
+#                         length = 8,
+#                         diameter = NA, 
+#                         heat = "Hot",
+#                         condiment = "NA")
+# 
+# p5 <- SupervisedModelDeploymentParams$new()
+# p5$type <- "classification"
+# p5$df <- dfDeploy5
+# p5$grainCol <- "id"
+# p5$personCol <- "vendorID"
+# p5$predictedCol <- "isHotDog"
+# p5$impute <- TRUE
+# p5$debug <- F
+# p5$cores <- 1


### PR DESCRIPTION
I added tests for random forest and lasso (classification and regression) and LMM (classification only) to check that
- single row predictions work
- predictions are independent of each other
- imputation is performed correctly on new factor levels

The new unit test file is pretty long.  I tried to compromise between avoiding lots of repeated code and tests being self contained (see #402) doing all the model development in the setup and all of the model deployment (including creating the new deploy sets) in the individual tests. 

While writing the tests, I ran into a few bugs which I tried to fix.  Changes to the code include
- Assigning factor levels after imputing new factor levels
- Assigning factor levels before performing predictions for random forest and LMM

I ran the tests and examples and did a CRAN check, all of which passed (or at least as well as they do for master).