### PR TITLE
Clean up rare factor level warning in develop

### DIFF
--- a/R/supervised-model-development.R
+++ b/R/supervised-model-development.R
@@ -247,11 +247,30 @@ SupervisedModelDevelopment <- R6Class("SupervisedModelDevelopment",
       
       # Print warning about factors with levels that occur infrequently
       if (length(lowLevels) > 0) {
-        warning('Each of the following categorical variable levels occurs 3 ', 
-                'times or fewer:\n',
-                paste('- ', names(lowLevels), ":", lowLevels, collapse = "\n"),
-                '\nThere is a chance that the model will not train on all of ',
-                'them. Consider grouping these together with other levels.')
+        # Detailed warning
+        warningMessage <- paste0('Each of the following categorical variable ',
+                                 'levels occurs 3 times or fewer:\n',
+                                 paste('- ', names(lowLevels), ":", lowLevels, 
+                                       collapse = "\n"),
+                                 '\nThere is a chance that the model will not ',
+                                 'train on all of them. Consider grouping ',
+                                 'these together with other levels.')
+        # Print shorter warning if there are many factor levels which occur
+        # infrequently
+        if (max(unlist(lapply(lowLevels, length))) > 5) {
+          warningMessage <- paste0('Each of the following categorical ',
+                                   'variables has levels that occur 3 times or',
+                                   ' fewer:\n',
+                                   paste('- ', names(lowLevels), ":",
+                                         lapply(lowLevels, length), "levels",
+                                         collapse = "\n"),
+                                   '\nThere is a chance that the model will ',
+                                   'not train on all of them. Consider ',
+                                   'grouping these together with other levels.',
+                                   ' You can view the levels of a column using',
+                                   ' the "table" command.')
+        }
+        warning(warningMessage)
       }
       
       if (isTRUE(self$params$debug)) {

--- a/R/supervised-model-development.R
+++ b/R/supervised-model-development.R
@@ -252,9 +252,8 @@ SupervisedModelDevelopment <- R6Class("SupervisedModelDevelopment",
                                  'levels occurs 3 times or fewer:\n',
                                  paste('- ', names(lowLevels), ":", lowLevels, 
                                        collapse = "\n"),
-                                 '\nThere is a chance that the model will not ',
-                                 'train on all of them. Consider grouping ',
-                                 'these together with other levels.')
+                                 '\nConsider grouping these together with ',
+                                 'other levels.')
         # Print shorter warning if there are many factor levels which occur
         # infrequently
         if (max(unlist(lapply(lowLevels, length))) > 5) {
@@ -264,10 +263,9 @@ SupervisedModelDevelopment <- R6Class("SupervisedModelDevelopment",
                                    paste('- ', names(lowLevels), ":",
                                          lapply(lowLevels, length), "levels",
                                          collapse = "\n"),
-                                   '\nThere is a chance that the model will ',
-                                   'not train on all of them. Consider ',
-                                   'grouping these together with other levels.',
-                                   ' You can view the levels of a column using',
+                                   '\nConsider grouping these together with ',
+                                   'other levels.\n',
+                                   'You can view the levels of a column using',
                                    ' the "table" command.')
         }
         warning(warningMessage)

--- a/tests/testthat/test-XGBoost-deploy-pushes-to-sql.R
+++ b/tests/testthat/test-XGBoost-deploy-pushes-to-sql.R
@@ -40,7 +40,7 @@ p$xgb_params <- list("objective" = "multi:softprob",
 # Text of warning that we know will trigger and that we want to suppress
 warningText = paste("Each of the following categorical variable levels occurs ",
                     "3 times or fewer:\n-  x6 : Class1\n-  x27 : Class1\n-  ",
-                    "x33 : Class1\nThere is a chance",
+                    "x33 : Class1\nConsider grouping",
                     sep = "")
 
 #### BEGIN TESTS ####

--- a/tests/testthat/test-xgboost-deploy.R
+++ b/tests/testthat/test-xgboost-deploy.R
@@ -74,7 +74,7 @@ p$xgb_params <- list("objective" = "multi:softprob",
 # Text of warning that we know will trigger and that we want to suppress
 warningText = paste("Each of the following categorical variable levels occurs ",
                     "3 times or fewer:\n-  x6 : Class1\n-  x27 : Class1\n-  ",
-                    "x33 : Class1\nThere is a chance",
+                    "x33 : Class1\nConsider grouping",
                     sep = "")
 # Run model
 xNew <- capture.output(ignoreSpecWarn(code = boost <- XGBoostDevelopment$new(p),

--- a/tests/testthat/test-xgboost-develop.R
+++ b/tests/testthat/test-xgboost-develop.R
@@ -35,7 +35,7 @@ p$xgb_params <- list("objective" = "multi:softprob",
 # Text of warning that we know will trigger and that we want to suppress
 warningText = paste("Each of the following categorical variable levels occurs ",
                     "3 times or fewer:\n-  x6 : Class1\n-  x27 : Class1\n-  ",
-                    "x33 : Class1\nThere is a chance",
+                    "x33 : Class1\nConsider grouping",
                     sep = "")
 # Run model
 xNew <- capture.output(ignoreSpecWarn(code = boost <- XGBoostDevelopment$new(p), 


### PR DESCRIPTION
When there are many rare factor levels (more than 5 for a single variable), the warning will now print the number of rare factor levels for each factor variable rather than a full list of names. I also removed the sentence explaining that rare factor levels might not be used in training since I suspect that it would lead to more confusion than enlightenment. The warning for factor levels which are not used in training the model still lists all levels regardless of how many there are.

For example, compare the following:

Old warnings:
```
Warning messages:
1: In private$loadData() :
  Each of the following categorical variable levels occurs 3 times or fewer:
-  fruit : c("apricot", "cherry", "currant", "grape", "guava", "kiwi", "lime", "loops", "lychee", "nectarine", "orange", "papaya", "peach", "pineapple")
-  num : c("1", "11", "12", "14", "16", "17", "18", "19", "21", "22", "23", "24", "27", "28", "29", "3", "30", "31", "34", "35", "36", "37", "38", "4", "40", "41", "42", "43", "44", "46", "48", "50", "6", "8", "9")
There is a chance that the model will not train on all of them. Consider grouping these together with other levels.
2: In private$loadData() :
  The following categorical variable levels were not used in training the model:
-  fruit : lime
-  num : c("1", "21", "31", "34")
```

New warnings:
```
Warning messages:
1: In private$loadData() :
  Each of the following categorical variables has levels that occur 3 times or fewer:
-  fruit : 14 levels
-  num : 35 levels
Consider grouping these together with other levels.
You can view the levels of a column using the "table" command.
2: In private$loadData() :
  The following categorical variable levels were not used in training the model:
-  fruit : lime
-  num : c("1", "21", "31", "34")
```