### PR TITLE
Levy758travislint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
       CXX1X=g++-4.9
       CXX1XSTD=-std=c++11
     after_success:
-      - Rscript -e 'lintr::lint_package()'
+      - Rscript -e 'lintr::lint_package(linters = lintr::default_linters[!grepl("object_usage", names(lintr::default_linters))])'
       - Rscript -e 'covr::codecov()'
       
   - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ matrix:
       CXX1X=g++-4.9
       CXX1XSTD=-std=c++11
     after_success:
+      - Rscript -e 'lintr::lint_package()'
       - Rscript -e 'covr::codecov()'
       
   - os: osx

--- a/R/control_chart.R
+++ b/R/control_chart.R
@@ -91,7 +91,7 @@ control_chart <- function(d, measure, x, group1, group2,
     x <- "x"
     d$x <- seq_len(nrow(d))
   } else if (!x %in% names(d)) {
-    stop("You provided x = \"", x, 
+    stop("You provided x = \"", x,
          "\" but that isn't the name of a column in ", match.call()[["d"]])
   }
 

--- a/tests/testthat/test-lint.R
+++ b/tests/testthat/test-lint.R
@@ -1,7 +1,6 @@
-if (requireNamespace("lintr", quietly = TRUE)) {
-  context("lints")
-  test_that("Package Style", {
-    lintr::expect_lint_free()
-  })
-}
-
+context("lints")
+test_that("Package is lint free", {
+  skip_on_appveyor()
+  skip_on_travis()
+  lintr::expect_lint_free()
+})


### PR DESCRIPTION
Closes #758 

Changes: 
- tests-lint.R: Skip on travis and appveyor. When you test locally you'll fail for lints, but they won't fail remotely.
- .travis.yml: lint after success so that the lintr bot will still visit us to leave comments
- control_chart.R: Remove a lint I missed in a branch I already merged