### PR TITLE
Turn off notification emails in refactor branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ notifications:
       - taylor.miller@healthcatalyst.com
       - michael.levy@healthcatalyst.com
     on_success: never
-    on_failure: always
+    on_failure: never
   slack:
     secure: KIZYbmeATHXsbryDcrq6b4H6gtg3vrZIqZArbBpXd9Xp5ApHuGs0PYrYfWWMJmrZH+kNI4OK9DxxFRZdu59955Khev3dNyuGTMS0yRaRvqypi+0LUzbw+ha938l5Y3/OnK0Ke6WvX97r0xDX1vr5c/NMVzecZQGgIzi3PVY9TE1woXabtDlD7yvs2CrGabifGQUfkvEdRgGFUCXqPgckC4I66wVHJp6EWvVqiSPnsmMHEtTUnYmgxlR9YDPKHz/AKVKhvSh3ny4BoLBODqZuHSda4s8vtB8fNQMlXp0L+6lb1Y7tdXurfwUpde4uXfl5iCS8h/6h3Fk2WMjooztDdXCHqPLOKCXcqaJQELlYH4IBZPO/CIz2ljfp8SH4QXn5Bjm4ZJbfYGZiqmwlngJ7TZdtEyVsfL5JzjdsMucL4MOfZSKUypDERZVqdnKZmNfIfe5d410v08zNBrJ0lLezQMAwT+hNJejja88NMlRQKMRDuCxn01hUfGNRkZWyVhpdU6yry7cGSKM5np+/Rnjqf9BXevMv4h3HNpeSCzzugpCZFwOlC31Tny4j/hQOz3CHluNaHTSaf+eFV+6MX+OFIAwuuVTuxC0To5PA59JHkl+XiUssxIDMifsyBRxCm4+fxWZUsYXd0u7l81ultEJ78R41K6cwx2fOxhL3UE3obPQ=
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,4 +55,4 @@ notifications:
      - healthcatalystslc+appveyor@mailbox.org
    subject: 'r-appveyor build {{status}}'
    on_build_success: false
-   on_build_failure: true
+   on_build_failure: false


### PR DESCRIPTION
@levithatcher -- I turned off travis and appveyor emails for the refactor branches here. Did you turn off appveyor emails for all branches? If so, go ahead and turn that back on... I think it's good for us to get emails if master fails.