### PR TITLE
remove all-NA outcome column from prep_data in deployment

### DIFF
--- a/R/hcai-impute.R
+++ b/R/hcai-impute.R
@@ -120,7 +120,7 @@ hcai_impute <- function(recipe,
   # Numerics
   if (!all_nominal) {
     if (numeric_method == "mean") {
-      recipe <- step_meanimpute(recipe, all_numeric())
+      recipe <- step_meanimpute(recipe, all_numeric(), - all_outcomes())
     } else if (numeric_method == "bagimpute") {
       recipe <- step_bagimpute(
         recipe,

--- a/R/prep_data.R
+++ b/R/prep_data.R
@@ -108,6 +108,8 @@ prep_data <- function(d,
   if (!is.data.frame(d)) {
     stop("\"d\" must be a data frame.")
   }
+  outcome <- rlang::enquo(outcome)
+  remove_outcome <- FALSE
   # Deal with "..." columns to be ignored
   ignore_columns <- rlang::quos(...)
   ignored <- purrr::map_chr(ignore_columns, rlang::quo_name)
@@ -145,6 +147,13 @@ prep_data <- function(d,
     if (length(missing_vars))
       stop("These variables were present in training but are missing or ignored here: ",
            paste(missing_vars, collapse = ", "))
+    # Outcome gets added as all NAs; set a flag to remove it at end
+    if (rlang::quo_is_missing(outcome)) {
+      outcome_var <- recipe$var_info$variable[recipe$var_info$role == "outcome"]
+      if (length(outcome_var))
+        remove_outcome <- TRUE
+    }
+
   } else {
 
     # Initialize a new recipe
@@ -152,7 +161,6 @@ prep_data <- function(d,
     ## Start by making all variables predictors...
     recipe <- recipes::recipe(d, ~ .)
     ## Then deal with outcome if present
-    outcome <- rlang::enquo(outcome)
     if (!rlang::quo_is_missing(outcome)) {
       outcome_name <- rlang::quo_name(outcome)
       if (!outcome_name %in% names(d))
@@ -307,14 +315,15 @@ prep_data <- function(d,
     warning("Removing these near-zero variance columns: ",
             paste(nzv_removed, collapse = ", "))
 
+  # Remove outcome if recipe was provided but outcome not present
+  if (remove_outcome)
+    d <- d[, -which(names(d) == outcome_var), drop = FALSE]
   # Add ignore columns back in and attach as attribute to recipe
   d <- dplyr::bind_cols(d_ignore, d)
   attr(recipe, "ignored_columns") <- unname(ignored)
   attr(d, "recipe") <- recipe
   d <- tibble::as_tibble(d)
   class(d) <- c("hcai_prepped_df", class(d))
-
-  # TODO: Remove unused factor levels with droplevels. (MAYBE)
   return(d)
 }
 

--- a/R/prep_data.R
+++ b/R/prep_data.R
@@ -316,7 +316,7 @@ prep_data <- function(d,
             paste(nzv_removed, collapse = ", "))
 
   # Remove outcome if recipe was provided but outcome not present
-  if (remove_outcome)
+  if (remove_outcome && outcome_var %in% names(d))
     d <- d[, -which(names(d) == outcome_var), drop = FALSE]
   # Add ignore columns back in and attach as attribute to recipe
   d <- dplyr::bind_cols(d_ignore, d)

--- a/tests/testthat/test-prep_data.R
+++ b/tests/testthat/test-prep_data.R
@@ -421,3 +421,9 @@ test_that("prep_data leaves newly created dummies as 0/1", {
   d <- data.frame(x = 1:10, y = rep(letters[1:2], len = 10))
   expect_true(all(prep_data(d, center = TRUE, scale = TRUE)[["y_b"]] %in% 0:1))
 })
+
+test_that("If recipe provided but no outcome column, NA-outcome column isn't created", {
+  expect_false("is_ween" %in% names(
+    prep_data(dplyr::select(d_test, -is_ween), song_id, recipe = attr(d_prep, "recipe"))
+  ))
+})

--- a/tests/testthat/test-prep_data.R
+++ b/tests/testthat/test-prep_data.R
@@ -434,3 +434,10 @@ test_that("predict regression with prep doesn't choke without outcome", {
     predict(dplyr::select(pima_diabetes[51:55, ], -age)) %>%
     expect_s3_class("hcai_predicted_df")
 })
+
+test_that("predict classification with prep doesn't choke without outcome", {
+  prep_data(pima_diabetes[1:50, ], outcome = diabetes) %>%
+    tune_models(diabetes, models = "rf") %>%
+    predict(dplyr::select(pima_diabetes[51:55, ], -diabetes)) %>%
+    expect_s3_class("hcai_predicted_df")
+})

--- a/tests/testthat/test-prep_data.R
+++ b/tests/testthat/test-prep_data.R
@@ -427,3 +427,10 @@ test_that("If recipe provided but no outcome column, NA-outcome column isn't cre
     prep_data(dplyr::select(d_test, -is_ween), song_id, recipe = attr(d_prep, "recipe"))
   ))
 })
+
+test_that("predict regression with prep doesn't choke without outcome", {
+  prep_data(pima_diabetes[1:50, ], outcome = age) %>%
+    tune_models(age, models = "rf") %>%
+    predict(dplyr::select(pima_diabetes[51:55, ], -age)) %>%
+    expect_s3_class("hcai_predicted_df")
+})


### PR DESCRIPTION
Previously, when passing a recipe to `prep_data`, if the outcome variable wasn't present in `d` the return added it with all NAs. This adds a check for the condition and just wipes this column before returning the data frame.

Closes #908 

ETA: Fixes #922 