### PR TITLE
add cohesion_weight arg to best_levels. Closes #1131.

### DIFF
--- a/man/add_best_levels.Rd
+++ b/man/add_best_levels.Rd
@@ -7,11 +7,11 @@
 factors}
 \usage{
 add_best_levels(d, longsheet, id, groups, outcome, n_levels = 100,
-  min_obs = 1, positive_class = "Y", levels = NULL, fill, fun = sum,
-  missing_fill = NA)
+  min_obs = 1, positive_class = "Y", cohesion_weight = 2, levels = NULL,
+  fill, fun = sum, missing_fill = NA)
 
 get_best_levels(d, longsheet, id, groups, outcome, n_levels = 100,
-  min_obs = 1, positive_class = "Y")
+  min_obs = 1, positive_class = "Y", cohesion_weight = 2)
 }
 \arguments{
 \item{d}{Data frame to use in models, at desired grain. Has id and outcome}
@@ -37,6 +37,11 @@ because a level present in only a few observation will rarely be a useful.}
 
 \item{positive_class}{If classification model, the positive class of the
 outcome, default = "Y"; ignored if regression}
+
+\item{cohesion_weight}{For classification problems only, how much to value a
+level being consistently associated with an outcome relative to its being
+present in many observations. Default = 2; equal weight is 1. Note that
+this is a parameter that could potentially be tuned over.}
 
 \item{levels}{Use this argument when add_best_levels was used in training and
 you want to add the same columns for deployment. You can pass the model
@@ -99,13 +104,18 @@ Here is how \code{get_best_levels} determines the levels of
   (i.e. centered_mean(group) / sqrt(var(group) / n(group))), and the groups
   with the largest absolute values of that statistic are retained.} \item{For
   classification: For each group, two "log-loss-like" statistics are
-  calculated. One is log of the fraction of observations in which the group
-  does not appear. The other is the log of the difference of the proportion
-  of different outcomes from all the same outcome (e.g. if 4/5 observations
-  are positive class, this statistic is log(.2)). To ensure retainment of
-  both positive- and negative-predictors, the all-same-outcome that is used
-  as the comparison is determined by which side of the median proportion of
-  positive_class the group falls on.}}
+  calculated. One is the log of the fraction of observations in which the
+  group does not appear, which captures how ubiquitous the group is: more
+  common groups are more useful as predictors. The other captures how far the
+  group is from being always associated with the same outcome: groups that
+  are consistently assoicated with either outcome are more useful as
+  predictors. This is calculated as the log of the proportion of outcomes
+  that are not all the same outcome (e.g. if 4/5 observations are positive
+  class, this statistic is log(.2)). This value is then raised to the
+  \code{cohesion_weight} power. To ensure retainment of both positive- and
+  negative-predictors, the all-same-outcome that is used as the comparison is
+  determined by which side of the median proportion of positive_class the
+  group falls on.}}
 }
 \examples{
 set.seed(45796)


### PR DESCRIPTION
cohesion weight is how much to relatively weight a level being consistently associated with one outcome class, vs a level being present in many observations. Defaults to two, which is an exponent on the log-loss from being associated entirely with one class