### PR TITLE
Write error message and test

### DIFF
--- a/R/machine_learn.R
+++ b/R/machine_learn.R
@@ -103,6 +103,11 @@ machine_learn <- function(d, ..., outcome, models, metric, tune = TRUE, positive
   if (!is.data.frame(d))
     stop("\"d\" must be a data frame.")
 
+  if ("prepped_df" %in% class(d))
+    stop("\"d\" is already prepped. Either use original data in ",
+         "`machine_learn`, or use prepped data in `flash_models` or ",
+         "`tune_models`.")
+
   dots <- rlang::quos(...)
   ignored <- map_chr(dots, rlang::quo_name)
   if (length(ignored)) {

--- a/tests/testthat/test-flash_models.R
+++ b/tests/testthat/test-flash_models.R
@@ -112,7 +112,6 @@ test_that("flash_models doesn't need an outcome specified", {
 
 test_that("multiclass warns when classes are sparse", {
   expect_warning(
-    machine_learn(m_df2, patient_id, outcome = many_chars,
-                  models = "rf", tune = FALSE),
+    flash_models(m_df2, outcome = many_chars, models = "rf"),
     "sparse")
 })

--- a/tests/testthat/test-machine_learn.R
+++ b/tests/testthat/test-machine_learn.R
@@ -118,3 +118,12 @@ test_that("Machine learn respects tune = FALSE", {
   expect_s3_class(ut, "multiclass_list")
   expect_false(attr(ut, "tuned"))
 })
+
+test_that("Machine learn throws error if given prepped object", {
+  prepped_d <- prep_data(pima_diabetes, patient_id, outcome = diabetes)
+  expect_error(
+    m <- machine_learn(prepped_d, patient_id, outcome = diabetes, models = "rf",
+                       tune = FALSE),
+    "\"d\" is already prepped"
+  )
+})


### PR DESCRIPTION
@mmastand, we ran into this bug at HAS. It was an easy fix.

``` r
library(healthcareai)
#> healthcareai version 2.2.0
#> Please visit https://docs.healthcare.ai for full documentation and vignettes. Join the community at https://healthcare-ai.slack.com
library(tidyverse)

prepped_d <- prep_data(pima_diabetes, patient_id, outcome = diabetes)
#> Training new data prep recipe...
m <- machine_learn(prepped_d, patient_id, outcome = diabetes, models = "rf", 
                   tune = FALSE)
#> Error in machine_learn(prepped_d, patient_id, outcome = diabetes, models = "rf", : "d" is already prepped. Either use original data in `machine_learn`, or use prepped data in `flash_models` or `tune_models`.
```

Created on 2018-09-20 by the [reprex
package](http://reprex.tidyverse.org) (v0.2.0).