### PR TITLE
Rex 795 updatehcaiimputewarning

### DIFF
--- a/R/hcai-impute.R
+++ b/R/hcai-impute.R
@@ -100,10 +100,14 @@ hcai_impute <- function(recipe,
 
   # Fill in user-specified params
   num_p <- nom_p <- defaults
-  num_p[names(num_p) %in% names(numeric_params)] <- numeric_params
-  nom_p[names(nom_p) %in% names(nominal_params)] <- nominal_params
+  suppressWarnings( # Silence confusing warning when params don't match
+    num_p[names(num_p) %in% names(numeric_params)] <- numeric_params
+  )
+  suppressWarnings(
+    nom_p[names(nom_p) %in% names(nominal_params)] <- nominal_params
+  )
 
-  # Warn if extra bag names
+  # Warn if params don't match chosen imputation method
   check_params(possible_numeric_methods, numeric_method, numeric_params)
   check_params(possible_nominal_method, nominal_method, nominal_params)
 
@@ -176,14 +180,14 @@ check_params <- function(possible_methods, cur_method, cur_params) {
       matched_params <- names(cur_params) %in% available_params[[.x]]
       new_params <- names(cur_params)[!matched_params]
       if (length(new_params)) {
-        mes <-
+        available_params_mes <-
           if (is.null(available_params[[.x]]))
-            paste0("There are no required parameters for ", .x, ".")
+            paste0("There are not available parameters for ", .x, ".")
           else
-            paste0("Available params are: ",
+            paste0("Available ", .x, " params are: ",
                    list_variables(available_params[[.x]]), ".")
-        warning("You have extra imputation parameters that won't be used for ",
-                .x, ": ", list_variables(new_params), ". ", mes)
+        warning("The following extra parameters won't be used for ", .x, ": ",
+                list_variables(new_params), ". ", available_params_mes)
       }
     }
   })

--- a/R/hcai-impute.R
+++ b/R/hcai-impute.R
@@ -84,7 +84,7 @@ hcai_impute <- function(recipe,
          or \"knnimpute\"")
   }
   possible_nominal_methods <- c("new_category", "bagimpute", "knnimpute")
-  if (!(nominal_method %in% possible_nominal_method)) {
+  if (!(nominal_method %in% possible_nominal_methods)) {
     stop("non-supported nominal method. Use \"new_category\", \"bagimpute\",
          or \"knnimpute\"")
   }

--- a/R/hcai-impute.R
+++ b/R/hcai-impute.R
@@ -83,7 +83,7 @@ hcai_impute <- function(recipe,
     stop("non-supported numeric method. Use \"mean\", \"bagimpute\",
          or \"knnimpute\"")
   }
-  possible_nominal_method <- c("new_category", "bagimpute", "knnimpute")
+  possible_nominal_methods <- c("new_category", "bagimpute", "knnimpute")
   if (!(nominal_method %in% possible_nominal_method)) {
     stop("non-supported nominal method. Use \"new_category\", \"bagimpute\",
          or \"knnimpute\"")
@@ -109,7 +109,7 @@ hcai_impute <- function(recipe,
 
   # Warn if params don't match chosen imputation method
   check_params(possible_numeric_methods, numeric_method, numeric_params)
-  check_params(possible_nominal_method, nominal_method, nominal_params)
+  check_params(possible_nominal_methods, nominal_method, nominal_params)
 
   # Catch datasets where all predictors are of one type
   vi <- recipe$var_info

--- a/R/hcai-impute.R
+++ b/R/hcai-impute.R
@@ -160,6 +160,9 @@ hcai_impute <- function(recipe,
   return(recipe)
 }
 
+
+#' Throws a warning if the parameters given don't match the supported parameters
+#' @noRd
 check_params <- function(possible_methods, cur_method, cur_params) {
   available_params <- list(
     knnimpute = c("knn_K", "impute_with", "seed_val"),
@@ -175,13 +178,12 @@ check_params <- function(possible_methods, cur_method, cur_params) {
       if (length(new_params)) {
         mes <-
           if (is.null(available_params[[.x]]))
-            paste0(.x, " doesn't take any parameters")
+            paste0("There are no required parameters for ", .x, ".")
           else
             paste0("Available params are: ",
-                   list_variables(available_params[[.x]]))
+                   list_variables(available_params[[.x]]), ".")
         warning("You have extra imputation parameters that won't be used for ",
-                .x, ": ", list_variables(new_params),
-                ". ", mes)
+                .x, ": ", list_variables(new_params), ". ", mes)
       }
     }
   })

--- a/tests/testthat/test-hcai-impute.R
+++ b/tests/testthat/test-hcai-impute.R
@@ -84,7 +84,7 @@ test_that("Non-supported params throw warnings.", {
   expect_warning(
     recipe %>%
       hcai_impute(numeric_method = "knnimpute",
-        numeric_params = list(knn_K = 5, bag_model = "m")),
+                  numeric_params = list(knn_K = 5, bag_model = "m")),
     regexp = "bag_model"
   )
   expect_warning(

--- a/tests/testthat/test-hcai-impute.R
+++ b/tests/testthat/test-hcai-impute.R
@@ -84,14 +84,26 @@ test_that("Non-supported params throw warnings.", {
   expect_warning(
     recipe %>%
       hcai_impute(numeric_method = "knnimpute",
-        numeric_params = list(knn_K = 5, more_cowbell = TRUE)),
-    regexp = "more_cowbell"
+        numeric_params = list(knn_K = 5, bag_model = "m")),
+    regexp = "bag_model"
   )
   expect_warning(
     recipe %>%
       hcai_impute(nominal_method = "bagimpute",
-                  nominal_params = list(bag_model = "m", prune = TRUE)),
-    regexp = "prune"
+                  nominal_params = list(bag_model = "m", knn_K = 5)),
+    regexp = "knn_K"
+  )
+  expect_warning(
+    recipe %>%
+      hcai_impute(nominal_method = "new_category",
+                  nominal_params = list(knn_K = 5)),
+    regexp = "knn_K"
+  )
+  expect_warning(
+    recipe %>%
+      hcai_impute(numeric_method = "mean",
+                  numeric_params = list(bag_model = "m")),
+    regexp = "bag_model"
   )
 })
 


### PR DESCRIPTION
@mmastand this should be another quick one. I spent some time to make sure the logic was as simple as possible. Rather than creating an if statement for every check, I created a function that can be called in every circumstance to check the parameters.

I also suppressed other warnings that are raised when parameters don't match. I thought it would be best to suppress these so that the user doesn't get confused by them. Thoughts?

Let me know if you don't like variable names, or you think that anything can be improved. Thanks!

``` r
library(healthcareai)
#> healthcareai version 2.2.0
#> Please visit https://docs.healthcare.ai for full documentation and vignettes. Join the community at https://healthcare-ai.slack.com
library(tidyverse)
library(recipes)
#> Loading required package: broom
#> 
#> Attaching package: 'recipes'
#> The following object is masked from 'package:stringr':
#> 
#>     fixed
#> The following object is masked from 'package:stats':
#> 
#>     step

d <- pima_diabetes

recipe(diabetes ~ ., data = d) %>%
  hcai_impute(numeric_method = "mean",
              numeric_params = list(bag_model = "m"))
#> Warning in .f(.x[[i]], ...): The following extra parameters won't be used
#> for mean: bag_model. There are not available parameters for mean.
#> Data Recipe
#> 
#> Inputs:
#> 
#>       role #variables
#>    outcome          1
#>  predictor          9
#> 
#> Operations:
#> 
#> Mean Imputation for all_numeric(), -all_outcomes()
#> Filling NA with missing for all_nominal(), -all_outcomes()

recipe(diabetes ~ ., data = d) %>%
  hcai_impute(nominal_method = "new_category",
              nominal_params = list(knn_K = 5))
#> Warning in .f(.x[[i]], ...): The following extra parameters won't be
#> used for new_category: knn_K. There are not available parameters for
#> new_category.
#> Data Recipe
#> 
#> Inputs:
#> 
#>       role #variables
#>    outcome          1
#>  predictor          9
#> 
#> Operations:
#> 
#> Mean Imputation for all_numeric(), -all_outcomes()
#> Filling NA with missing for all_nominal(), -all_outcomes()

recipe(diabetes ~ ., data = d) %>%
  hcai_impute(nominal_method = "bagimpute",
              nominal_params = list(bag_model = "m", knn_K = 5, not_param = 3))
#> Warning in .f(.x[[i]], ...): The following extra parameters won't be
#> used for bagimpute: knn_K and not_param. Available bagimpute params are:
#> bag_model, bag_options, impute_with, and seed_val.
#> Data Recipe
#> 
#> Inputs:
#> 
#>       role #variables
#>    outcome          1
#>  predictor          9
#> 
#> Operations:
#> 
#> Mean Imputation for all_numeric(), -all_outcomes()
#> Bagged tree imputation for all_nominal(), -all_outcomes()

recipe(diabetes ~ ., data = d) %>%
  hcai_impute(numeric_method = "knnimpute",
              numeric_params = list(knn_K = 5, bag_model = "m"),
              nominal_method = "bagimpute",
              nominal_params = list(bag_model = "m", knn_K = 5))
#> Warning in .f(.x[[i]], ...): The following extra parameters won't be
#> used for knnimpute: bag_model. Available knnimpute params are: knn_K,
#> impute_with, and seed_val.
#> Warning in .f(.x[[i]], ...): The following extra parameters won't be
#> used for bagimpute: knn_K. Available bagimpute params are: bag_model,
#> bag_options, impute_with, and seed_val.
#> Data Recipe
#> 
#> Inputs:
#> 
#>       role #variables
#>    outcome          1
#>  predictor          9
#> 
#> Operations:
#> 
#> m-nearest neighbor imputation for all_numeric(), -all_outcomes()
#> Bagged tree imputation for all_nominal(), -all_outcomes()
```

Created on 2018-10-04 by the [reprex
package](http://reprex.tidyverse.org) (v0.2.0).