### PR TITLE
Rex 1254 bugnumericknnimpute

### DIFF
--- a/R/hcai-impute.R
+++ b/R/hcai-impute.R
@@ -154,10 +154,11 @@ hcai_impute <- function(recipe,
         class(.x) %>% first()
       }))
         warning("`bagimpute` depends on another library that does not support",
-                " character columns yet. If `bagimpute` does not impute missing",
-                " values, please convert all character columns to factors. If ",
-                "`collapse_rare_factors` is TRUE, the values that are not ",
-                'imputed might be contained in "other".')
+                " character columns yet. Check `bagimpute` by setting ",
+                "`collapse_rare_factors = FALSE`, and verify that missing ",
+                "values have been imputed with `missingness()`. If `bagimpute`",
+                " does not impute missing values, please convert all character",
+                " columns to factors.")
       recipe <- step_bagimpute(
         recipe,
         all_nominal(),

--- a/R/hcai-impute.R
+++ b/R/hcai-impute.R
@@ -130,8 +130,10 @@ hcai_impute <- function(recipe,
         impute_with = num_p$impute_with,
         seed_val = num_p$seed_val)
     } else if (numeric_method == "knnimpute") {
-      if ("character" %in% map_chr(recipe$template, ~{class(.x)}))
-        warning("`knnimpute` depends on another library that does not support ",
+      if ("character" %in% map_chr(recipe$template, ~{
+        class(.x)
+      }))
+        message("`knnimpute` depends on another library that does not support ",
                 "character columns yet. If `knnimpute` fails please convert ",
                 "all character columns to factors for bag imputation.")
       recipe <- step_knnimpute(
@@ -149,7 +151,9 @@ hcai_impute <- function(recipe,
     if (nominal_method == "new_category") {
       recipe <- step_missing(recipe, all_nominal(), - all_outcomes())
     } else if (nominal_method == "bagimpute") {
-      if ("character" %in% map_chr(recipe$template, ~{class(.x)}))
+      if ("character" %in% map_chr(recipe$template, ~{
+        class(.x)
+      }))
         warning("`bagimpute` depends on another library that does not support",
                 " character columns yet. If `bagimpute` does not impute missing",
                 " values, please convert all character columns to factors. If ",
@@ -163,8 +167,10 @@ hcai_impute <- function(recipe,
         impute_with = nom_p$impute_with,
         seed_val = nom_p$seed_val)
     }  else if (nominal_method == "knnimpute") {
-      if ("character" %in% map_chr(recipe$template, ~{class(.x)}))
-        warning("`knnimpute` depends on another library that does not support ",
+      if ("character" %in% map_chr(recipe$template, ~{
+        class(.x)
+      }))
+        message("`knnimpute` depends on another library that does not support ",
                 "character columns yet. If `knnimpute` fails please convert ",
                 "all character columns to factors for bag imputation.")
       recipe <- step_knnimpute(

--- a/R/hcai-impute.R
+++ b/R/hcai-impute.R
@@ -131,7 +131,7 @@ hcai_impute <- function(recipe,
         seed_val = num_p$seed_val)
     } else if (numeric_method == "knnimpute") {
       if ("character" %in% map_chr(recipe$template, ~{
-        class(.x)
+        class(.x) %>% first()
       }))
         message("`knnimpute` depends on another library that does not support ",
                 "character columns yet. If `knnimpute` fails please convert ",
@@ -152,7 +152,7 @@ hcai_impute <- function(recipe,
       recipe <- step_missing(recipe, all_nominal(), - all_outcomes())
     } else if (nominal_method == "bagimpute") {
       if ("character" %in% map_chr(recipe$template, ~{
-        class(.x)
+        class(.x) %>% first()
       }))
         warning("`bagimpute` depends on another library that does not support",
                 " character columns yet. If `bagimpute` does not impute missing",
@@ -168,7 +168,7 @@ hcai_impute <- function(recipe,
         seed_val = nom_p$seed_val)
     }  else if (nominal_method == "knnimpute") {
       if ("character" %in% map_chr(recipe$template, ~{
-        class(.x)
+        class(.x) %>% first()
       }))
         message("`knnimpute` depends on another library that does not support ",
                 "character columns yet. If `knnimpute` fails please convert ",

--- a/R/hcai-impute.R
+++ b/R/hcai-impute.R
@@ -130,6 +130,10 @@ hcai_impute <- function(recipe,
         impute_with = num_p$impute_with,
         seed_val = num_p$seed_val)
     } else if (numeric_method == "knnimpute") {
+      if ("character" %in% map_chr(recipe$template, ~{class(.x)}))
+        warning("`knnimpute` depends on another library that does not support ",
+                "character columns yet. If `knnimpute` fails please convert ",
+                "all character columns to factors for bag imputation.")
       recipe <- step_knnimpute(
         recipe,
         all_numeric(), - all_outcomes(),
@@ -145,6 +149,12 @@ hcai_impute <- function(recipe,
     if (nominal_method == "new_category") {
       recipe <- step_missing(recipe, all_nominal(), - all_outcomes())
     } else if (nominal_method == "bagimpute") {
+      if ("character" %in% map_chr(recipe$template, ~{class(.x)}))
+        warning("`bagimpute` depends on another library that does not support",
+                " character columns yet. If `bagimpute` does not impute missing",
+                " values, please convert all character columns to factors. If ",
+                "`collapse_rare_factors` is TRUE, the values that are not ",
+                'imputed might be contained in "other".')
       recipe <- step_bagimpute(
         recipe,
         all_nominal(),
@@ -153,6 +163,10 @@ hcai_impute <- function(recipe,
         impute_with = nom_p$impute_with,
         seed_val = nom_p$seed_val)
     }  else if (nominal_method == "knnimpute") {
+      if ("character" %in% map_chr(recipe$template, ~{class(.x)}))
+        warning("`knnimpute` depends on another library that does not support ",
+                "character columns yet. If `knnimpute` fails please convert ",
+                "all character columns to factors for bag imputation.")
       recipe <- step_knnimpute(
         recipe,
         all_nominal(), - all_outcomes(),

--- a/R/hcai-impute.R
+++ b/R/hcai-impute.R
@@ -134,7 +134,7 @@ hcai_impute <- function(recipe,
       }))
         message("`knnimpute` depends on another library that does not support ",
                 "character columns yet. If `knnimpute` fails please convert ",
-                "all character columns to factors for bag imputation.")
+                "all character columns to factors for knn imputation.")
       recipe <- step_knnimpute(
         recipe,
         all_numeric(), - all_outcomes(),
@@ -172,7 +172,7 @@ hcai_impute <- function(recipe,
       }))
         message("`knnimpute` depends on another library that does not support ",
                 "character columns yet. If `knnimpute` fails please convert ",
-                "all character columns to factors for bag imputation.")
+                "all character columns to factors for knn imputation.")
       recipe <- step_knnimpute(
         recipe,
         all_nominal(), - all_outcomes(),

--- a/tests/testthat/test-hcai-impute.R
+++ b/tests/testthat/test-hcai-impute.R
@@ -33,6 +33,7 @@ df$hot_dog[df["condiment"] == "Syrup"] <-
 # Add noise
 df$hot_dog <- df$hot_dog + rnorm(n, mean = 0, sd = 1.25)
 df$hot_dog <- ifelse(df$hot_dog > 0, "Y", "N")
+df$hot_dog <- as.factor(df$hot_dog)
 
 # Add missing data
 df$condiment[sample(1:n, 32, replace = FALSE)] <- NA
@@ -160,16 +161,13 @@ test_that("bag imputation bakes expected results", {
   expect_equal(d_imputed$length[14], 7.797, tolerance = 2)
 })
 
-test_that("random columns don't get imputed", {
-  # If a categorical column is completely uncorrelated with other columns, bag
-  # impute will not fill in the missing data. This test is mostly just to make
-  # sure this function is behaving as it was when it was written.
-
+test_that("random columns get imputed when factors", {
   # add randomly distributed columns with NAs
   df$random_chars <- sample(c("NYC", "Chicago"), n, replace = TRUE)
   df$random_nums <- sample(1:n, n, replace = FALSE)
   df$random_chars[sample(1:n, 55, replace = FALSE)] <- NA
   df$random_nums[sample(1:n, 45, replace = FALSE)] <- NA
+  df$random_chars <- as.factor(df$random_chars)
 
   d_train <- df[train_index$Resample1, ]
   d_test <- df[-train_index$Resample1, ]
@@ -184,7 +182,7 @@ test_that("random columns don't get imputed", {
                           prep(training = d_train) %>%
                           bake(newdata = d_test))
 
-  expect_true(any(missingness(d_imputed, return_df = FALSE) != 0))
+  expect_false(any(missingness(d_imputed, return_df = FALSE) != 0))
 
   # knn
   recipe <- recipe(hot_dog ~ ., data = d_train)
@@ -193,7 +191,7 @@ test_that("random columns don't get imputed", {
                                       nominal_method = "knnimpute") %>%
                           prep(training = d_train))
 
-  expect_error(prepped %>% bake(newdata = d_test))
+  expect_error(prepped %>% bake(newdata = d_test), NA)
 })
 
 test_that("all nominal or all numeric columns add 1 step", {
@@ -210,4 +208,49 @@ test_that("all nominal or all numeric columns add 1 step", {
     hcai_impute() %>%
     prep(training = nom_dat)
   expect_equal(length(rec$steps), 1)
+})
+
+test_that("test warning for bag imputation mal function", {
+  df$heat <- as.character(df$heat)
+  df$condiment <- as.character(df$condiment)
+
+  expect_warning(
+    out_data <-
+      recipe(hot_dog ~ ., data = df) %>%
+      hcai_impute(nominal_method = "bagimpute") %>%
+      prep() %>%
+      bake(newdata = df),
+    "`bagimpute` depends on another library"
+  )
+  # If this not true, recipes has fixed bag imputation. Please remove the
+  # warning above.
+  expect_true(any(is.na(out_data)))
+
+  expect_warning(
+    my_recipe <-
+      recipe(hot_dog ~ ., data = df) %>%
+      hcai_impute(numeric_method = "knnimpute"),
+    "`knnimpute` depends on another library"
+  )
+  # If this is not throwing an error, recipes has fixed knn imputation. Please
+  # remove the warning above.
+  expect_error(
+    prep(my_recipe) %>%
+      bake(newdata = df),
+    regexp = "STRING_ELT()"
+  )
+
+  expect_warning(
+    my_recipe <-
+      recipe(hot_dog ~ ., data = df) %>%
+      hcai_impute(nominal_method = "knnimpute"),
+    "`knnimpute` depends on another library"
+  )
+  # If this is not throwing an error, recipes has fixed knn imputation. Please
+  # remove the warning above.
+  expect_error(
+    prep(my_recipe) %>%
+      bake(newdata = df),
+    regexp = "STRING_ELT()"
+  )
 })

--- a/tests/testthat/test-hcai-impute.R
+++ b/tests/testthat/test-hcai-impute.R
@@ -226,7 +226,7 @@ test_that("test warning for bag imputation mal function", {
   # warning above.
   expect_true(any(is.na(out_data)))
 
-  expect_warning(
+  expect_message(
     my_recipe <-
       recipe(hot_dog ~ ., data = df) %>%
       hcai_impute(numeric_method = "knnimpute"),
@@ -240,7 +240,7 @@ test_that("test warning for bag imputation mal function", {
     regexp = "STRING_ELT()"
   )
 
-  expect_warning(
+  expect_message(
     my_recipe <-
       recipe(hot_dog ~ ., data = df) %>%
       hcai_impute(nominal_method = "knnimpute"),


### PR DESCRIPTION
@mmastand, this issues raises warnings and messages for issues #1254 and #998.

When errors were thrown it was difficult to see the warning message, so I decided to make these messages. In R these messages are displayed nicely. Let me know what you think.

Summary of changes:
- For issue #1254 I raised messages because errors are thrown with character columns
- For issue #998 I raised a warning to alert the user. In this issue, `recipes` succeeds, but just doesn't impute. Sometimes it is masked when `collapse_rare_factors = TRUE`.

I also changed a test. I didn't agree with the comment. It said that imputation shouldn't work with random variables. I don't think this would be an issue. After I changed the introduced column to factor type the imputation worked.. When you are looking at the tests you might not agree with what I have done. Let me know what you think. Thank you!

``` r
library(healthcareai)
#> healthcareai version 2.2.0
#> Please visit https://docs.healthcare.ai for full documentation and vignettes. Join the community at https://healthcare-ai.slack.com

prep_data(pima_diabetes, outcome = age, impute=list(nominal_method="knnimpute"))
#> Training new data prep recipe...
#> `knnimpute` depends on another library that does not support character columns yet. If `knnimpute` fails please convert all character columns to factors for bag imputation.
#> Error in gower_work(x = x, y = y, pair_x = pair_x, pair_y = pair_y, n = n, : STRING_ELT() can only be applied to a 'character vector', not a 'integer'
prep_data(pima_diabetes, outcome = age, impute=list(numeric_method="knnimpute"))
#> Training new data prep recipe...
#> `knnimpute` depends on another library that does not support character columns yet. If `knnimpute` fails please convert all character columns to factors for bag imputation.
#> Error in gower_work(x = x, y = y, pair_x = pair_x, pair_y = pair_y, n = n, : STRING_ELT() can only be applied to a 'character vector', not a 'integer'
prep_data(pima_diabetes, outcome = age, impute=list(nominal_method="bagimpute"))
#> Training new data prep recipe...
#> Warning in hcai_impute(., numeric_method = ip$numeric_method,
#> nominal_method = ip$nominal_method, : `bagimpute` depends on another
#> library that does not support character columns yet. If `bagimpute` does
#> not impute missing values, please convert all character columns to factors.
#> If `collapse_rare_factors` is TRUE, the values that are not imputed might
#> be contained in "other".
#> healthcareai-prepped data. Recipe used to prepare data:
#> Data Recipe
#> 
#> Inputs:
#> 
#>       role #variables
#>    outcome          1
#>  predictor          9
#> 
#> Training data contained 768 data points and 376 incomplete rows. 
#> 
#> Operations:
#> 
#> Sparse, unbalanced variable filter removed no terms [trained]
#> Mean Imputation for patient_id, pregnancies, ... [trained]
#> Bagged tree imputation for weight_class, diabetes [trained]
#> Adding levels to: other, missing [trained]
#> Collapsing factor levels for weight_class, diabetes [trained]
#> Adding levels to: other, missing [trained]
#> Dummy variables from weight_class and diabetes [trained]
#> Current data:
#> # A tibble: 768 x 16
#>    patient_id pregnancies plasma_glucose diastolic_bp skinfold insulin
#>         <int>       <int>          <dbl>        <dbl>    <dbl>   <dbl>
#>  1          1           6            148         72       35      156.
#>  2          2           1             85         66       29      156.
#>  3          3           8            183         64       29.2    156.
#>  4          4           1             89         66       23       94 
#>  5          5           0            137         40       35      168 
#>  6          6           5            116         74       29.2    156.
#>  7          7           3             78         50       32       88 
#>  8          8          10            115         72.4     29.2    156.
#>  9          9           2            197         70       45      543 
#> 10         10           8            125         96       29.2    156.
#> # ... with 758 more rows, and 10 more variables: pedigree <dbl>,
#> #   age <int>, weight_class_morbidly.obese <dbl>,
#> #   weight_class_normal <dbl>, weight_class_overweight <dbl>,
#> #   weight_class_other <dbl>, weight_class_missing <dbl>,
#> #   diabetes_Y <dbl>, diabetes_other <dbl>, diabetes_missing <dbl>
```

Created on 2018-10-04 by the [reprex
package](http://reprex.tidyverse.org) (v0.2.0).