### PR TITLE
changed packageVersion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 #### Changed
 
 - `bagimpute` in `prep_data` now accepts `bag_trees` to specify the number of trees. This is updated to be compatible with [recipes 0.1.4](https://github.com/tidymodels/recipes/blob/master/NEWS.md).
+- Local loaded `healthcareai` library versions now are saved to model objects.
 
 # healthcareai 2.2.0
 

--- a/R/train_models.R
+++ b/R/train_models.R
@@ -58,7 +58,7 @@ attach_session_info <- function(x) {
   structure(x,
             versions = list(
               r_version = paste0(si$R.version$major, ".", si$R.version$minor),
-              hcai_version = installed.packages()["healthcareai", "Version"],
+              hcai_version = packageVersion("healthcareai"),
               other_packages =
                 purrr::map_chr(si$loadedOnly, ~ .x$Version) %>%
                 tibble::tibble(package = names(.), version = .))


### PR DESCRIPTION
@mmastand this was a quick patch. It took longer to make reprex examples for this issue. There is some issue with reprex examples calling packageVersion with libraries installed from tar.gz files, so I cannot make a reprex example before and after. It works on my computer though..

Also, there are no tests for this. I don't know of a way to test it. There weren't past tests for it either.

If you would like to test this manually I have provided some code. Ask me if you have any questions

```{R}
#install old version of healthcareai to main library
remotes::install_github("HealthCatalyst/healthcareai-r@v2.1.0", force = TRUE)
## install version 2.3 to test library 
# make sure to have the most recent versions of recipes and caret
install.packages("/Users/rex.sumsion/Documents/healthcareai_2.3.0.tar.gz",
                 lib = "~/Desktop/sandbox/test_hcai3/", repos = NULL,
                 type="source")

library(healthcareai, lib = "~/Desktop/sandbox/test_hcai3/")
packageVersion("healthcareai")

m <- machine_learn(pima_diabetes, patient_id, outcome = diabetes, tune = FALSE)
attr(m, "versions")$hcai_version
```