### PR TITLE
avoid deprecation warnings and errors

### DIFF
--- a/R/control_chart.R
+++ b/R/control_chart.R
@@ -101,7 +101,7 @@ control_chart <- function(d, measure, x, group1, group2, #nolint
     geom_line() +
     geom_point(aes(color = outside), size = 2) +
     scale_color_manual(values = c("out" = "firebrick", "in" = "black"),
-                                guide = FALSE) +
+                                guide = "none") +
     labs(title = title, caption = catpion) +
     theme_gray(base_size = font_size) +
     theme(panel.grid.major.y = element_blank(),

--- a/R/hcai-impute.R
+++ b/R/hcai-impute.R
@@ -16,14 +16,14 @@
 #'  only), \code{bag_options} (bagimpute only), \code{bag_trees}
 #'  (bagimpute only), \code{knn_K} (knnimpute only), \code{impute_with}
 #'  (knnimpute only), (bag or knn) or \code{seed_val} (bag or knn).
-#'  See \link{step_bagimpute} or \link{step_knnimpute} for details.
+#'  See \link{step_impute_bag} or \link{step_impute_knn} for details.
 #' @param nominal_params A named list with parmeters to use with
 #'  chosen imputation method on nominal data. Options are
 #'  \code{bag_model} (bagimpute only), \code{bag_trees} (bagimpute
 #'  only), \code{bag_options} (bagimpute only), \code{bag_trees}
 #'  (bagimpute only), \code{knn_K} (knnimpute only), \code{impute_with}
 #'  (knnimpute only), (bag or knn) or \code{seed_val} (bag or knn).
-#'  See \link{step_bagimpute} or \link{step_knnimpute} for details.
+#'  See \link{step_impute_bag} or \link{step_impute_knn} for details.
 #' @return An updated version of `recipe` with the new step
 #'  added to the sequence of existing steps.
 #'
@@ -126,9 +126,9 @@ hcai_impute <- function(recipe,
   # Numerics
   if (!all_nominal) {
     if (numeric_method == "mean") {
-      recipe <- step_meanimpute(recipe, all_numeric(), - all_outcomes())
+      recipe <- step_impute_mean(recipe, all_numeric(), - all_outcomes())
     } else if (numeric_method == "bagimpute") {
-      recipe <- step_bagimpute(
+      recipe <- step_impute_bag(
         recipe,
         all_numeric(), - all_outcomes(),
         models = num_p$bag_model,
@@ -143,7 +143,7 @@ hcai_impute <- function(recipe,
         message("`knnimpute` depends on another library that does not support ",
                 "character columns yet. If `knnimpute` fails please convert ",
                 "all character columns to factors for knn imputation.")
-      recipe <- step_knnimpute(
+      recipe <- step_impute_knn(
         recipe,
         all_numeric(), - all_outcomes(),
         neighbors = num_p$knn_K,
@@ -162,7 +162,7 @@ hcai_impute <- function(recipe,
     if (nominal_method == "new_category") {
       recipe <- step_missing(recipe, all_nominal(), - all_outcomes())
     } else if (nominal_method == "bagimpute") {
-      recipe <- step_bagimpute(
+      recipe <- step_impute_bag(
         recipe,
         all_nominal(),
         models = nom_p$bag_model, - all_outcomes(),
@@ -171,7 +171,7 @@ hcai_impute <- function(recipe,
         impute_with = nom_p$impute_with,
         seed_val = nom_p$seed_val)
     } else if (nominal_method == "knnimpute") {
-      recipe <- step_knnimpute(
+      recipe <- step_impute_knn(
         recipe,
         all_nominal(), - all_outcomes(),
         neighbors = nom_p$knn_K,

--- a/R/impute.R
+++ b/R/impute.R
@@ -22,14 +22,14 @@
 #'  only), \code{bag_options} (bagimpute only), \code{bag_trees}
 #'  (bagimpute only), \code{knn_K} (knnimpute only), \code{impute_with}
 #'  (knnimpute only), (bag or knn) or \code{seed_val} (bag or knn).
-#'  See \link{step_bagimpute} or \link{step_knnimpute} for details.
+#'  See \link{step_impute_bag} or \link{step_impute_knn} for details.
 #' @param nominal_params A named list with parmeters to use with chosen
 #'   imputation method on nominal data. Options are
 #'  \code{bag_model} (bagimpute only), \code{bag_trees} (bagimpute
 #'  only), \code{bag_options} (bagimpute only), \code{bag_trees}
 #'  (bagimpute only), \code{knn_K} (knnimpute only), \code{impute_with}
 #'  (knnimpute only), (bag or knn) or \code{seed_val} (bag or knn).
-#'  See \link{step_bagimpute} or \link{step_knnimpute} for details.
+#'  See \link{step_impute_bag} or \link{step_impute_knn} for details.
 #' @param verbose Gives a print out of what will be imputed and which method
 #'   will be used.
 #' @return Imputed data frame with reusable recipe object for future imputation

--- a/R/missingness.R
+++ b/R/missingness.R
@@ -112,7 +112,7 @@ plot.missingness <- function(x, remove_zeros = FALSE, max_char = 40,
                        labels = function(x) paste0(x, "%"),
                        limits = c(0, NA)) +
     scale_color_manual(values = c("TRUE" = "darkgray", "FALSE" = "black"),
-                       guide = FALSE)
+                       guide = "none")
     ggtitle(title) +
     theme_gray(base_size = font_size)
 

--- a/R/model_list_generics.R
+++ b/R/model_list_generics.R
@@ -144,8 +144,8 @@ plot.model_list <- function(x, font_size = 11, point_size = 1,
             geom_point(size = point_size) +
             coord_flip() +
             scale_y_continuous(limits = y_range) +
-            scale_color_discrete(guide = FALSE) +
-            scale_shape_manual(values = c("TRUE" = 17, "FALSE" = 16), guide = FALSE) +
+            scale_color_discrete(guide = "none") +
+            scale_shape_manual(values = c("TRUE" = 17, "FALSE" = 16), guide = "none") +
             xlab(NULL) +
             labs(title = .x) +
             theme_gray(base_size = font_size)

--- a/healthcareai-r.Rproj
+++ b/healthcareai-r.Rproj
@@ -17,5 +17,6 @@ StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
+PackageCleanBeforeInstall: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageRoxygenize: rd,collate,namespace,vignette

--- a/man/hcai_impute.Rd
+++ b/man/hcai_impute.Rd
@@ -28,7 +28,7 @@ chosen imputation method on numeric data. Options are
 only), \code{bag_options} (bagimpute only), \code{bag_trees}
 (bagimpute only), \code{knn_K} (knnimpute only), \code{impute_with}
 (knnimpute only), (bag or knn) or \code{seed_val} (bag or knn).
-See \link{step_bagimpute} or \link{step_knnimpute} for details.}
+See \link{step_impute_bag} or \link{step_impute_knn} for details.}
 
 \item{nominal_params}{A named list with parmeters to use with
 chosen imputation method on nominal data. Options are
@@ -36,7 +36,7 @@ chosen imputation method on nominal data. Options are
 only), \code{bag_options} (bagimpute only), \code{bag_trees}
 (bagimpute only), \code{knn_K} (knnimpute only), \code{impute_with}
 (knnimpute only), (bag or knn) or \code{seed_val} (bag or knn).
-See \link{step_bagimpute} or \link{step_knnimpute} for details.}
+See \link{step_impute_bag} or \link{step_impute_knn} for details.}
 }
 \value{
 An updated version of `recipe` with the new step

--- a/man/impute.Rd
+++ b/man/impute.Rd
@@ -39,7 +39,7 @@ training dataset in production.}
 only), \code{bag_options} (bagimpute only), \code{bag_trees}
 (bagimpute only), \code{knn_K} (knnimpute only), \code{impute_with}
 (knnimpute only), (bag or knn) or \code{seed_val} (bag or knn).
-See \link{step_bagimpute} or \link{step_knnimpute} for details.}
+See \link{step_impute_bag} or \link{step_impute_knn} for details.}
 
 \item{nominal_params}{A named list with parmeters to use with chosen
  imputation method on nominal data. Options are
@@ -47,7 +47,7 @@ See \link{step_bagimpute} or \link{step_knnimpute} for details.}
 only), \code{bag_options} (bagimpute only), \code{bag_trees}
 (bagimpute only), \code{knn_K} (knnimpute only), \code{impute_with}
 (knnimpute only), (bag or knn) or \code{seed_val} (bag or knn).
-See \link{step_bagimpute} or \link{step_knnimpute} for details.}
+See \link{step_impute_bag} or \link{step_impute_knn} for details.}
 
 \item{verbose}{Gives a print out of what will be imputed and which method
 will be used.}

--- a/man/step_dummy_hcai.Rd
+++ b/man/step_dummy_hcai.Rd
@@ -47,11 +47,11 @@ not provided for a nominal variable, the mode value will be used as the
 reference level.}
 
 \item{skip}{A logical. Should the step be skipped when the
-recipe is baked by \code{\link[recipes:bake]{bake.recipe()}}? While all operations are baked
-when \code{\link[recipes:prep]{prep.recipe()}} is run, some operations may not be able to be
+recipe is baked by \code{\link[recipes:bake]{bake()}}? While all operations are baked
+when \code{\link[recipes:prep]{prep()}} is run, some operations may not be able to be
 conducted on new data (e.g. processing the outcome variable(s)).
 Care should be taken when using \code{skip = TRUE} as it may affect
-the computations for subsequent operations}
+the computations for subsequent operations.}
 
 \item{id}{A character string that is unique to this step to identify it.}
 

--- a/tests/testthat/test-hcai-impute.R
+++ b/tests/testthat/test-hcai-impute.R
@@ -66,7 +66,7 @@ test_that("Defaults return mean on numeric, hcai on nominal", {
   rec_obj_new <- recipe %>%
     hcai_impute()
 
-  expect_equal(class(rec_obj_new$steps[[1]])[1], "step_meanimpute")
+  expect_equal(class(rec_obj_new$steps[[1]])[1], "step_impute_mean")
   expect_equal(class(rec_obj_new$steps[[2]])[1], "step_missing")
 })
 
@@ -119,21 +119,21 @@ test_that("Non-supported params throw warnings.", {
 test_that("bag impute called on both types", {
   rec_obj_new <- recipe %>%
     hcai_impute(numeric_method = "bagimpute")
-  expect_equal(class(rec_obj_new$steps[[1]])[1], "step_bagimpute")
+  expect_equal(class(rec_obj_new$steps[[1]])[1], "step_impute_bag")
 
   rec_obj_new <- recipe %>%
     hcai_impute(nominal_method = "bagimpute")
-  expect_equal(class(rec_obj_new$steps[[2]])[1], "step_bagimpute")
+  expect_equal(class(rec_obj_new$steps[[2]])[1], "step_impute_bag")
 })
 
 test_that("knnimpute impute called on both types", {
   rec_obj_new <- recipe %>%
     hcai_impute(numeric_method = "knnimpute")
-  expect_equal(class(rec_obj_new$steps[[1]])[1], "step_knnimpute")
+  expect_equal(class(rec_obj_new$steps[[1]])[1], "step_impute_knn")
 
   rec_obj_new <- recipe %>%
     hcai_impute(nominal_method = "knnimpute")
-  expect_equal(class(rec_obj_new$steps[[2]])[1], "step_knnimpute")
+  expect_equal(class(rec_obj_new$steps[[2]])[1], "step_impute_knn")
 })
 
 test_that("knnimpute impute called on both types", {


### PR DESCRIPTION
recipes 1.0.0 will go to CRAN around June 13th and there are some errors here from using deprecated functions. The PR also fixes some ggplot2 warnings by using the suggested version of `guide`. 