### PR TITLE
PR to avoid error with new recipes update

### DIFF
--- a/R/explore.R
+++ b/R/explore.R
@@ -122,7 +122,11 @@ explore <- function(models,
   variables <-
     rec$var_info %>%
     dplyr::filter(role == "predictor") %>%
-    dplyr::mutate(type = dplyr::case_when(type == "logical" ~ "numeric",
+    dplyr::mutate(type = purrr::map_chr(type, paste, collapse = "_")) %>%
+    dplyr::mutate(type = dplyr::case_when(type == "string_unordered_nominal" ~ "nominal",
+                                          type == "integer_numeric" ~ "numeric",
+                                          type == "double_numeric" ~ "numeric",
+                                          type == "logical" ~ "numeric",
                                           TRUE ~ type)) %>%
     split(., .$type) %>%
     purrr::map(dplyr::pull, variable)

--- a/R/globals.R
+++ b/R/globals.R
@@ -15,7 +15,7 @@ utils::globalVariables(c("outside", "percent_missing", "variable", ".outcome",
                          "threshold", "to", "value", "role", "quantiles",
                          "predicted_group", "minimum_probability", "Var1",
                          "Var2", "freq", "actual_freq", "percent", "model.matrix",
-                         "Freq"))
+                         "Freq", "type"))
 
 printer <- utils::getFromNamespace("printer", "recipes")
 

--- a/R/hcai-impute.R
+++ b/R/hcai-impute.R
@@ -120,8 +120,12 @@ hcai_impute <- function(recipe,
 
   # Catch datasets where all predictors are of one type
   vi <- recipe$var_info
-  all_nominal <- !any(vi$type[vi$role == "predictor"] == "numeric")
-  all_numeric <- !any(vi$type[vi$role == "predictor"] == "nominal")
+  all_nominal <- !any(
+    purrr::map_int(vi$type[vi$role == "predictor"], ~ "numeric" %in% .x)
+  )
+  all_numeric <- !any(
+    purrr::map_int(vi$type[vi$role == "predictor"], ~ "nominal" %in% .x)
+  )
 
   # Numerics
   if (!all_nominal) {

--- a/R/prep_data.R
+++ b/R/prep_data.R
@@ -367,7 +367,9 @@ prep_data <- function(d,
     prep_check <- recipes::prep(recipe, training = d)
     removing <- prep_check$steps[[1]]$removals
     vi <- recipe$var_info
-    nom_preds <- vi$variable[vi$role == "predictor" & vi$type == "nominal"]
+    nom_preds <- vi$variable[
+      vi$role == "predictor" & purrr::map_lgl(vi$type, ~ "nominal" %in% .x)
+    ]
     if (length(nom_preds) && all(nom_preds %in% removing))
       stop("All your categorical columns will be removed because they have ",
            "near-zero variance, which will break prep_data. ",
@@ -446,7 +448,8 @@ prep_data <- function(d,
 
     # If there are numeric predictors, apply numeric transformations
     var_info <- recipe$var_info
-    if (any(var_info$type == "numeric" & var_info$role == "predictor")) {
+    if (any(purrr::map_lgl(var_info$type, ~ "numeric" %in% .x) &
+              var_info$role == "predictor")) {
 
       # Log transform
       # Saving until columns can be specified
@@ -467,7 +470,8 @@ prep_data <- function(d,
     }
 
     # If there are nominal predictors, apply nominal transformations
-    if (any(var_info$type == "nominal" & var_info$role == "predictor")) {
+    if (any(purrr::map_lgl(var_info$type, ~ "nominal" %in% .x) &
+              var_info$role == "predictor")) {
 
       # Add protective levels --------------------------------------------------
       if (add_levels)

--- a/R/step_add_levels.R
+++ b/R/step_add_levels.R
@@ -49,8 +49,7 @@ step_add_levels_new <- function(terms = NULL, role = NA, trained = FALSE,
 #' @export
 prep.step_add_levels <- function(x, training, info) {
   col_names <- recipes::recipes_eval_select(quos = x$terms, data = training, info = info)
-  if (any(info$type[info$variable %in% col_names] != "nominal"))
-    stop("step_add_levels is only appropriate for nominal variables")
+  recipes::check_type(training[, col_names], quant = FALSE)
   step_add_levels_new(terms = x$terms, role = x$role, trained = TRUE,
                       cols = col_names, levels = x$levels, skip = x$skip,
                       id = x$id)

--- a/tests/testthat/test-explore.R
+++ b/tests/testthat/test-explore.R
@@ -9,6 +9,12 @@ multi <- machine_learn(na.omit(pima_diabetes[1:200, ]), patient_id, outcome = we
 variabs <-
   attr(m, "recipe")$var_info %>%
   dplyr::filter(role == "predictor") %>%
+  dplyr::mutate(type = purrr::map_chr(type, paste, collapse = "_")) %>%
+  dplyr::mutate(type = dplyr::case_when(type == "string_unordered_nominal" ~ "nominal",
+                                        type == "integer_numeric" ~ "numeric",
+                                        type == "double_numeric" ~ "numeric",
+                                        type == "logical" ~ "numeric",
+                                        TRUE ~ type)) %>%
   split(., .$type) %>%
   purrr::map(dplyr::pull, variable)
 sm <- explore(m)

--- a/tests/testthat/test-predict.R
+++ b/tests/testthat/test-predict.R
@@ -253,7 +253,7 @@ test_that("ready_with_prep preps appropriately", {
   rec <- attr(model_regression_prepped, "recipe")
   predictors <-
     rec$var_info %>%
-    dplyr::filter(role == "predictor" & type == "numeric") %>%
+    dplyr::filter(role == "predictor" & purrr::map_lgl(type, ~ "numeric" %in% .x)) %>%
     dplyr::pull(variable) %>%
     c(paste0("Catholic", "_", c("Y", "other", "missing")))
   expect_setequal(prepped_predictors, predictors)


### PR DESCRIPTION
Hello @mmastand 👋 

When doing revdepchecking for https://github.com/tidymodels/recipes/pull/993, I found a couple of bug that appears in your variable type checking code, that used to work before, but now doesn't.

There were also some code that accessed and used the `var_info` element of a recipe which were causing some problems. Generally we recommend that you don't access elements of a recipe without an accessor function. Thomas wrote this post explaining this problem nicely here https://www.tidyverse.org/blog/2022/09/playing-on-the-same-team-as-your-dependecy/.

I would love to help to give pointers and review PRs that changes the code to avoid using `var_info` directly.

This PR fixes all the issue! And can be merged now as it isn't dependent on  https://github.com/tidymodels/recipes/pull/993.