### PR TITLE
Fix for dev purrr

### DIFF
--- a/R/globals.R
+++ b/R/globals.R
@@ -15,7 +15,7 @@ utils::globalVariables(c("outside", "percent_missing", "variable", ".outcome",
                          "threshold", "to", "value", "role", "quantiles",
                          "predicted_group", "minimum_probability", "Var1",
                          "Var2", "freq", "actual_freq", "percent", "model.matrix",
-                         "Freq"))
+                         "Freq", "is_numeric"))
 
 printer <- utils::getFromNamespace("printer", "recipes")
 


### PR DESCRIPTION
purrr used to export is_numeric() which masked the fact that you needed to delcare it as a global variable.