### PR TITLE
Replace 'glm' with 'glmnet' in package description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Description: Aims to make machine learning in healthcare as easy as possible.
   algorithm selection (between 
   'xgboost' Chen, T. & Guestrin, C. (2016) <arXiv:1603.02754>,
   'ranger' Wright, M. N., & Ziegler, A. (2017) <doi:10.18637/jss.v077.i01>,
-  and 'glm' Friedman J, Hastie T, Tibshirani R. (2010) <doi:10.18637/jss.v033.i01>) 
+  and 'glmnet' Friedman J, Hastie T, Tibshirani R. (2010) <doi:10.18637/jss.v033.i01>) 
   so that they can be easily
   put into production. Additionally, there are tools to help understand how a model makes its 
   predictions, select prediction threshholds for operational use, and evaluate model performance over time.


### PR DESCRIPTION
To make a distinction between `stats::glm()` and the `glmnet` R package.